### PR TITLE
添加mcp服务端支持

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ autojs/.cxx/ndk_locator_record_68547592.json
 autojs/.cxx/ndk_locator_record_68547592_key.json
 *.aab
 output-metadata.json
+/mcp/build/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# AGENTS
+
+## 项目概览
+- Autox.js v7：Android 上支持无障碍自动化的 JavaScript 运行与开发环境，基于 Auto.js 4.1 fork；许可证 MPL-2.0+非商业 + GPLv2（详见 README）。
+- 根模块：`app`（主应用与 IDE）、`autojs`（JS 引擎与 API，含 Rhino/Node via Javet）、`automator`（无障碍与控件操作层）、`common`（Compose UI 与工具）、`inrt`（模板运行时，生成 template.apk）、`apkbuilder`（脚本打包签名）、`codeeditor`（内置编辑器资源）、`paddleocr`（OCR 能力）。
+- 版本与 SDK 见 `project-versions.json`：Java 17，compile/target SDK 34，minSdk 27；`settings.gradle.kts` 列出全部模块。
+
+## 构建 & 运行
+- 先初始化子模块与依赖：`git submodule update --init --recursive` 获取 `docs/v2`；需要 Node.js 20+（JS API 构建、文档）与 Android SDK/NDK；当前已禁用 `foojay` 自动 JDK 下载（`settings.gradle.kts` 已移除插件）。
+- JS API 构建：`./gradlew autojs:buildJsModule`（运行 v6/v7 API Node 构建并拷贝到 assets）；变更 JS 模块后需重跑。
+- 模板产物：`app` 构建前会从 `inrt` 模板拷贝 `template.apk` 到 `app/src/main/assets`；若缺失会触发 `buildTemplateApp`。
+- 常用命令：
+  - Debug 安装：`./gradlew app:buildDebugTemplateApp app:assembleV7Debug app:installV7Debug`
+  - Release 包：`./gradlew app:buildTemplateApp app:assembleV7`
+  - 仅模板：`./gradlew inrt:assembleTemplateDebug` 或 `inrt:assembleTemplateRelease`
+- 内置代码编辑器资源由 `codeeditor:downloadEditor` 在预构建阶段自动下载（需网络）。
+
+## 开发环境缓存（本机已准备）
+- JDK 17：`C:\tools\jdk17\jdk-17.0.13+11`（构建时将 `JAVA_HOME` 指向此路径）。
+- Android SDK：`C:\android-sdk`（已安装 `platforms;android-34`、`build-tools;34.0.0`、`platform-tools`）。
+- `local.properties` 已写入 `sdk.dir=C:/android-sdk`，后续构建无需再次配置 SDK 路径。
+- Gradle Wrapper：`gradle-8.7`（`gradle/wrapper/gradle-wrapper.properties`）。
+
+## 测试
+- 连接 adb 设备后运行 `./gradlew autojs:assemble`（或在 Android Studio 触发一次构建）。
+- 在 `autojs/src/androidTest` 打开测试类并运行；设备端允许安装测试 APK 后继续。
+
+## 文档
+- 文档子模块位于 `docs/v2`（git 子模块指向 aiselp/AutoxDoc）。
+- 构建离线文档：`./gradlew app:buildDocs`（Node 构建 JS API 文档与 VuePress，然后拷贝到 `app/src/main/assets/docs/v2`）。
+
+## 其他提示
+- UI 主要基于 Compose/Material3，部分旧代码仍依赖 ButterKnife、RxJava2/3；`gradle.properties` 启用了 AndroidX/Jetifier、Gradle 并行与缓存。
+- 默认仅生成 arm64-v8a ABI（`app` splits 及 `apkbuilder` 设置），`inrt` template 渠道会剔除模型/资源。
+- 大型依赖（Javet、MLKit、ONNX、PaddleOCR 等）在网络受限场景可提前缓存本地 Maven/Gradle。

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -229,6 +229,7 @@ dependencies {
     implementation(project(":autojs"))
     implementation(project(":apkbuilder"))
     implementation(project(":codeeditor"))
+    implementation(project(":mcp"))
 
     // ViewModel
     implementation(libs.lifecycle.viewmodel.ktx)

--- a/app/src/main/java/org/autojs/autojs/App.kt
+++ b/app/src/main/java/org/autojs/autojs/App.kt
@@ -30,6 +30,7 @@ import org.autojs.autojs.theme.ThemeColorManagerCompat
 import org.autojs.autojs.timing.TimedTaskManager
 import org.autojs.autojs.timing.TimedTaskScheduler
 import org.autojs.autojs.ui.main.MainActivity
+import org.autojs.autojs.mcp.McpPreferenceBridge
 import org.autojs.autoxjs.BuildConfig
 import org.autojs.autoxjs.R
 import rikka.shizuku.ShizukuProvider
@@ -42,6 +43,7 @@ import java.lang.ref.WeakReference
 class App : Application(), Configuration.Provider {
     lateinit var dynamicBroadcastReceivers: DynamicBroadcastReceivers
         private set
+    private var mcpPreferenceBridge: McpPreferenceBridge? = null
 
 
     override fun onCreate() {
@@ -81,6 +83,7 @@ class App : Application(), Configuration.Provider {
             };
         } else if (ProcessUtils.isMainProcess(this)) {
             initResource()
+            mcpPreferenceBridge = McpPreferenceBridge(this).apply { start() }
             EngineController.scope.launch {
                 delay(1000)
                 ShizukuProvider.requestBinderForNonProviderProcess(this@App)

--- a/app/src/main/java/org/autojs/autojs/mcp/McpPreferenceBridge.kt
+++ b/app/src/main/java/org/autojs/autojs/mcp/McpPreferenceBridge.kt
@@ -1,0 +1,37 @@
+package org.autojs.autojs.mcp
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.preference.PreferenceManager
+import org.autojs.autoxjs.mcp.McpPrefKeys
+import org.autojs.autoxjs.mcp.McpServerService
+
+class McpPreferenceBridge(private val context: Context) :
+    SharedPreferences.OnSharedPreferenceChangeListener {
+    private val prefs = PreferenceManager.getDefaultSharedPreferences(context)
+
+    fun start() {
+        prefs.registerOnSharedPreferenceChangeListener(this)
+        applyState()
+    }
+
+    fun stop() {
+        prefs.unregisterOnSharedPreferenceChangeListener(this)
+        McpServerService.stop(context)
+    }
+
+    override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences?, key: String?) {
+        if (key == McpPrefKeys.KEY_ENABLED) {
+            applyState()
+        }
+    }
+
+    private fun applyState() {
+        val enabled = prefs.getBoolean(McpPrefKeys.KEY_ENABLED, false)
+        if (enabled) {
+            McpServerService.start(context)
+        } else {
+            McpServerService.stop(context)
+        }
+    }
+}

--- a/app/src/main/java/org/autojs/autojs/ui/settings/M3EditTextPreferenceDialogFragment.kt
+++ b/app/src/main/java/org/autojs/autojs/ui/settings/M3EditTextPreferenceDialogFragment.kt
@@ -10,6 +10,7 @@ import androidx.preference.EditTextPreference
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 
 class M3EditTextPreferenceDialogFragment(val preference: EditTextPreference) : DialogFragment() {
+    private var editText: EditText? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -21,6 +22,10 @@ class M3EditTextPreferenceDialogFragment(val preference: EditTextPreference) : D
             .setTitle(preference.dialogTitle)
             .setIcon(preference.dialogIcon)
             .setPositiveButton(preference.positiveButtonText) { _, _ ->
+                val value = editText?.text?.toString().orEmpty()
+                if (preference.callChangeListener(value)) {
+                    preference.text = value
+                }
             }
             .setNegativeButton(preference.negativeButtonText) { _, _ ->
             }
@@ -41,13 +46,15 @@ class M3EditTextPreferenceDialogFragment(val preference: EditTextPreference) : D
     }
 
     open fun onBindDialogView(view: View) {
-        val editText = view.findViewById<EditText>(android.R.id.edit)
-        checkNotNull(editText) {
+        val editView = view.findViewById<EditText>(android.R.id.edit)
+        checkNotNull(editView) {
             IllegalStateException(
                 "Dialog view must contain an EditText with id" + " @android:id/edit"
             )
         }
-        editText.setText(preference.text)
+        editView.setText(preference.text)
+        editView.setSelection(editView.text?.length ?: 0)
+        editText = editView
     }
 
     override fun onDismiss(dialog: DialogInterface) {

--- a/app/src/main/java/org/autojs/autojs/ui/settings/PreferenceFragment.kt
+++ b/app/src/main/java/org/autojs/autojs/ui/settings/PreferenceFragment.kt
@@ -3,6 +3,7 @@ package org.autojs.autojs.ui.settings
 import android.app.Activity
 import android.content.ComponentName
 import android.content.Context
+import android.content.SharedPreferences
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Bundle
@@ -15,9 +16,19 @@ import de.psdev.licensesdialog.LicensesDialog
 import org.autojs.autojs.external.open.RunIntentActivity
 import org.autojs.autojs.ui.widget.CommonMarkdownView
 import org.autojs.autoxjs.R
+import org.autojs.autoxjs.mcp.McpPrefKeys
+import org.autojs.autoxjs.mcp.McpServerService
 
-class PreferenceFragment : PreferenceFragmentCompat() {
+class PreferenceFragment : PreferenceFragmentCompat(), SharedPreferences.OnSharedPreferenceChangeListener {
     private val ACTION_MAP = mutableMapOf<String, (activity: Activity) -> Unit>()
+    private val mcpKeys = setOf(
+        McpPrefKeys.KEY_ENABLED,
+        McpPrefKeys.KEY_HOST,
+        McpPrefKeys.KEY_PORT,
+        McpPrefKeys.KEY_TOKEN,
+        McpPrefKeys.KEY_ALLOW_BASE64,
+        McpPrefKeys.KEY_ALLOW_NETWORK
+    )
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -39,6 +50,16 @@ class PreferenceFragment : PreferenceFragmentCompat() {
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         addPreferencesFromResource(R.xml.preferences)
+    }
+
+    override fun onResume() {
+        super.onResume()
+        preferenceManager.sharedPreferences?.registerOnSharedPreferenceChangeListener(this)
+    }
+
+    override fun onPause() {
+        preferenceManager.sharedPreferences?.unregisterOnSharedPreferenceChangeListener(this)
+        super.onPause()
     }
 
     override fun onDisplayPreferenceDialog(preference: Preference) {
@@ -78,6 +99,19 @@ class PreferenceFragment : PreferenceFragmentCompat() {
             true
         } else {
             super.onPreferenceTreeClick(preference)
+        }
+    }
+
+    override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences, key: String?) {
+        val safeKey = key ?: return
+        if (!mcpKeys.contains(safeKey)) {
+            return
+        }
+        val enabled = sharedPreferences.getBoolean(McpPrefKeys.KEY_ENABLED, false)
+        if (enabled) {
+            McpServerService.start(requireContext())
+        } else {
+            McpServerService.stop(requireContext())
         }
     }
 

--- a/app/src/main/res-i18n/values-en/strings.xml
+++ b/app/src/main/res-i18n/values-en/strings.xml
@@ -510,4 +510,17 @@
   <string name="text_reconnecting">Reconnecting</string>
   <string name="text_connecting">Connecting</string>
   <string name="text_handshake_failed">Handshake failed</string>
+  <string name="text_mcp">MCP Service</string>
+  <string name="text_mcp_enable">Enable MCP server</string>
+  <string name="summary_mcp_enable">Expose automation tools over a local port</string>
+  <string name="text_mcp_host">Bind address</string>
+  <string name="summary_mcp_host">Default is 0.0.0.0 for LAN; use 127.0.0.1 for local only</string>
+  <string name="text_mcp_port">Port</string>
+  <string name="summary_mcp_port">Default is 27190</string>
+  <string name="text_mcp_token">Access token</string>
+  <string name="summary_mcp_token">Empty means no auth</string>
+  <string name="text_mcp_allow_base64">Allow Base64 responses</string>
+  <string name="summary_mcp_allow_base64">Used for screenshots and OCR output</string>
+  <string name="text_mcp_allow_network">Allow LAN access</string>
+  <string name="summary_mcp_allow_network">Allow LAN access and non-localhost bind (default on)</string>
 </resources>

--- a/app/src/main/res-i18n/values/strings.xml
+++ b/app/src/main/res-i18n/values/strings.xml
@@ -58,6 +58,20 @@
     <string name="github">软件源代码</string>
     <string name="text_already_copy_to_clip">已复制到剪贴板</string>
     <string name="text_qq_already_copy_to_clip">QQ群号已复制到剪贴板</string>
+
+    <string name="text_mcp">MCP 服务</string>
+    <string name="text_mcp_enable">启用 MCP 服务</string>
+    <string name="summary_mcp_enable">启用后可通过本地端口调用自动化工具</string>
+    <string name="text_mcp_host">监听地址</string>
+    <string name="summary_mcp_host">默认监听 0.0.0.0；仅本机访问可改为 127.0.0.1</string>
+    <string name="text_mcp_port">监听端口</string>
+    <string name="summary_mcp_port">默认 27190</string>
+    <string name="text_mcp_token">访问令牌</string>
+    <string name="summary_mcp_token">为空则不校验</string>
+    <string name="text_mcp_allow_base64">允许返回 Base64</string>
+    <string name="summary_mcp_allow_base64">用于截图与 OCR 返回 Base64</string>
+    <string name="text_mcp_allow_network">允许局域网访问</string>
+    <string name="summary_mcp_allow_network">允许局域网访问并可绑定非 127.0.0.1（默认开启）</string>
     <string name="share_app">[Autox.js]下载地址：https://github.com/kkevsekk1/AutoX/releases </string>
     <string name="text_floating_window">悬浮窗</string>
     <string name="text_error_report">错误报告</string>

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -16,4 +16,11 @@
     <string name="key_guard_mode" translatable="false">key_guard_mode</string>
     <string name="key_intent_run_script" translatable="false" >key_intent_run_script</string>
     <string name="key_init_resource" translatable="false" >key_init_resource</string>
+
+    <string name="key_mcp_enabled" translatable="false">key_mcp_enabled</string>
+    <string name="key_mcp_host" translatable="false">key_mcp_host</string>
+    <string name="key_mcp_port" translatable="false">key_mcp_port</string>
+    <string name="key_mcp_token" translatable="false">key_mcp_token</string>
+    <string name="key_mcp_allow_base64" translatable="false">key_mcp_allow_base64</string>
+    <string name="key_mcp_allow_network" translatable="false">key_mcp_allow_network</string>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -112,6 +112,56 @@
 
     <PreferenceCategory
         android:layout="@layout/preference_category_custom"
+        android:title="@string/text_mcp">
+
+        <SwitchPreference
+            android:defaultValue="false"
+            android:key="@string/key_mcp_enabled"
+            android:layout="@layout/preference_custom"
+            android:summary="@string/summary_mcp_enable"
+            android:title="@string/text_mcp_enable" />
+
+        <EditTextPreference
+            android:defaultValue="0.0.0.0"
+            android:inputType="text"
+            android:key="@string/key_mcp_host"
+            android:layout="@layout/preference_custom"
+            android:summary="@string/summary_mcp_host"
+            android:title="@string/text_mcp_host" />
+
+        <EditTextPreference
+            android:defaultValue="27190"
+            android:inputType="number"
+            android:key="@string/key_mcp_port"
+            android:layout="@layout/preference_custom"
+            android:summary="@string/summary_mcp_port"
+            android:title="@string/text_mcp_port" />
+
+        <EditTextPreference
+            android:defaultValue=""
+            android:inputType="textPassword"
+            android:key="@string/key_mcp_token"
+            android:layout="@layout/preference_custom"
+            android:summary="@string/summary_mcp_token"
+            android:title="@string/text_mcp_token" />
+
+        <SwitchPreference
+            android:defaultValue="false"
+            android:key="@string/key_mcp_allow_base64"
+            android:layout="@layout/preference_custom"
+            android:summary="@string/summary_mcp_allow_base64"
+            android:title="@string/text_mcp_allow_base64" />
+
+        <SwitchPreference
+            android:defaultValue="true"
+            android:key="@string/key_mcp_allow_network"
+            android:layout="@layout/preference_custom"
+            android:summary="@string/summary_mcp_allow_network"
+            android:title="@string/text_mcp_allow_network" />
+    </PreferenceCategory>
+
+    <PreferenceCategory
+        android:layout="@layout/preference_category_custom"
         android:title="@string/text_about">
         <Preference
             android:layout="@layout/preference_custom"

--- a/autojs/build.gradle.kts
+++ b/autojs/build.gradle.kts
@@ -127,3 +127,7 @@ tasks.register("buildJsModule") {
     group = "build"
     dependsOn("buildV6Api", "buildV7Api")
 }
+
+tasks.named("preBuild") {
+    dependsOn("buildJsModule")
+}

--- a/docs/MCP_APP_MCP_SERVER_PLAN.md
+++ b/docs/MCP_APP_MCP_SERVER_PLAN.md
@@ -1,0 +1,54 @@
+# App 内嵌 MCP 服务端方案
+
+## 目标
+- 在 App 内提供符合 MCP 协议的工具端点，供 LLM 调用现有自动化能力（无障碍/脚本引擎/截图/OCR/应用控制）。
+- 默认安全、可控：仅本地或受信网段监听，强制鉴权、超时和速率控制，可随时停用。
+- 采用 Android 最佳实践：前台 Service 保活，协程结构化并发，配置持久化（DataStore），UI 开关可见。
+
+## 架构
+- 传输层：Ktor CIO + WebSockets/HTTP，默认监听 127.0.0.1，可配置网段与端口。
+- 协议层：MCP envelope；仅暴露工具（无资源通道），统一响应格式 `{ok|error, data?, errorCode?}`。
+- 执行层：复用现有组件——脚本引擎 v6/v7、automator 无障碍/手势、截图与 OCR、App 控制；脚本执行跑在独立协程/线程池，支持取消。
+- 保活与可视化：前台 Service + 通知显示“LLM 控制中”，设置页可一键停用。
+
+## 工具接口（首版）
+- `device_info`：设备、前台 Activity、屏幕方向、locale。
+- `run_script(script, mode=v7, timeout, args?)` → jobId；`job_status(jobId)`；`cancel_job(jobId)`。
+- `tap(x,y)` / `swipe(x1,y1,x2,y2,duration)`。
+- `find_element(criteria{text/id/desc/class}, timeout)` → bounds/center。
+- `screenshot(asBase64?=false)` → 临时路径或 base64。
+- `ocr(source=screenshot|path)` → 文本+位置信息。
+- `app_control(action=launch/force_stop/bring_to_front, package)`。
+- `logs(recent=N)`：最近调用/脚本输出。
+- 原“资源”工具化：`get_ui_tree()`（界面层级 JSON，节流）; `get_recent_screenshot(asBase64?=false)`（最近截图元信息/路径或 base64）。
+
+## 安全与限制
+- 鉴权：必需 token；监听地址/端口可配；可选仅在充电/解锁时启用。
+- 访问控制：文件白名单（仅 App 沙箱），禁止通配读写。
+- 资源保护：每工具强制超时；并发数/速率限制；大 payload（截图/base64/UI 树）做压缩或节流。
+- 观测：操作与错误日志；可选脱敏模式；调试模式下打印请求。
+
+## 组件设计
+- `McpServer`：启动/停止、路由注册、拦截器（鉴权/速率/超时）。
+- `ToolRegistry`：工具注册与分发，统一校验与错误码。
+- `ScriptRunner`：封装 v6/v7 执行，job 跟踪、取消、日志缓冲。
+- `AutomationBridge`：手势/查找/截图/OCR/App 控制门面，复用 automator、paddleocr/MLKit。
+- `Config`：端口/token/监听地址/返回格式，存 DataStore，设置页 UI 开关。
+- 前台 Service：通知 + 生命周期管理。
+
+## 实施计划
+1) 依赖与骨架：引入 `ktor-server-cio`、`ktor-server-websockets`、`ktor-serialization-json`；新建 `app/.../mcp` 包，`McpServer`+`ToolRegistry`+`healthcheck`；设置页/前台 Service 开关与配置存储。
+2) 基础工具：`device_info`、`screenshot`、`run_script`+`job_status`，统一响应/错误码/鉴权/超时。
+3) 自动化工具：`tap`/`swipe`/`find_element`/`app_control`/`ocr`，桥接 automator 与 OCR；确保线程/协程安全。
+4) 资源类工具：`get_ui_tree`、`get_recent_screenshot`，加节流与最大 payload 控制。
+5) 安全与可靠性：取消/超时覆盖所有工具；并发/压力测试；文件白名单、速率限制、日志脱敏；前台 Service 行为验证（不同厂商）。
+6) 测试与文档：真机验证全工具（含并发与长时间运行）；补充使用指南（启动、鉴权、工具示例）。
+
+## 配置与 UX
+- 设置页：开关、端口、监听地址、token、base64 返回开关、仅充电/解锁时启用，状态展示与错误提示。
+- 通知动作：快速停用/重启服务；显示当前连接状态。
+
+## 测试要点
+- 功能：各工具输入校验、超时、取消、错误码一致性。
+- 性能：并发调用（10+），截图/ocr 大 payload 压测，长时间运行内存与线程泄漏检查。
+- 兼容：多 Android 版本/厂商的前台 Service、无障碍行为；网络可用性（无网时本地回环仍可用）。

--- a/docs/MCP_USAGE.md
+++ b/docs/MCP_USAGE.md
@@ -1,0 +1,263 @@
+# MCP 模块使用说明
+
+本文介绍新引入的 `:mcp` 模块（App 内嵌 MCP 服务端）的使用方式、接口与集成步骤。
+
+## 能力概览
+- 基于 Ktor Netty 的轻量 MCP 工具端点，默认提供：
+  - `device_info`
+  - `run_script` → `job_status` / `cancel_job`
+  - `logs`
+  - `list_apps`
+  - `save_script` / `read_script` / `update_script` / `delete_script` / `rename_script`
+  - `list_samples` / `read_sample`
+  - `run_script_file`
+  - `list_scripts` / `list_script_dirs`
+  - `tap`、`swipe`、`find_element`、`find_elements`、`screenshot`、`ocr`、`app_control`、`get_foreground_app`、`get_current_activity`、`get_ui_tree`、`get_recent_screenshot`
+- tools 调用返回 JSON-RPC `result.content`，其中包含文本结果与 `isError` 标记。
+- 简易鉴权：请求头 `X-Token` 对比 `McpConfig.token`（为空则不校验）。
+
+## 运行/配置
+- 入口类：`org.autojs.autoxjs.mcp.McpService`（由 `McpServerService` 在 `:script` 进程中托管）
+- 配置结构：`McpConfig(enabled, host, port, token, allowBase64, allowNetwork)`
+- 设置页开关（推荐）：
+  - 进入“设置 → MCP 服务”
+  - 启用服务并配置监听地址/端口/Token
+  - 局域网访问：开启“允许局域网访问”，监听地址建议填 `0.0.0.0`
+  - 可选开启“允许返回 Base64”
+- 手动启动（仅调试用）：
+
+```kotlin
+// 例如在 Application.onCreate 或前台 Service 中
+val mcpService = McpService(applicationContext)
+val cfg = McpConfig(
+    enabled = true,
+    host = "0.0.0.0",
+    port = 27190,
+    token = "your-token"
+)
+mcpService.start(cfg)
+// 关闭：mcpService.stop()
+```
+
+> MCP 服务会以前台 Service 形式运行，通知栏会显示运行状态。
+
+## HTTP 调用方式
+
+### Streamable HTTP（标准 MCP JSON-RPC）
+- 端点：`POST http://{host}:{port}/mcp`
+- Header：`Content-Type: application/json`；`Accept: application/json, text/event-stream`；可选 `X-Token: <token>`
+- Body：单条 JSON-RPC 请求（tools-only 最小实现）。
+- 响应：当前实现返回 `application/json` 单响应（未启用 SSE 流式）。
+
+示例：
+```bash
+curl -X POST http://127.0.0.1:27190/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "X-Token: your-token" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"Demo"}}}'
+```
+
+```bash
+curl -X POST http://127.0.0.1:27190/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "X-Token: your-token" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'
+```
+
+```bash
+curl -X POST http://127.0.0.1:27190/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "X-Token: your-token" \
+  -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"tap","arguments":{"x":100,"y":200}}}'
+```
+
+### 工具调用示例（tools/call）
+- `run_script`
+```bash
+curl -X POST http://127.0.0.1:27190/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "X-Token: your-token" \
+  -d '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"run_script","arguments":{"script":"toast(\\"hi\\")","name":"hello","mode":"v7","timeoutMillis":20000}}}'
+```
+
+- `job_status`
+```bash
+curl -X POST http://127.0.0.1:27190/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "X-Token: your-token" \
+  -d '{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"job_status","arguments":{"jobId":1}}}'
+```
+
+- `cancel_job`
+```bash
+curl -X POST http://127.0.0.1:27190/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "X-Token: your-token" \
+  -d '{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"cancel_job","arguments":{"jobId":1}}}'
+```
+
+- `logs`
+```bash
+curl -X POST http://127.0.0.1:27190/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "X-Token: your-token" \
+  -d '{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"logs","arguments":{"recent":20}}}'
+```
+
+- `device_info`（无参数）
+```bash
+curl -X POST http://127.0.0.1:27190/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":8,"method":"tools/call","params":{"name":"device_info","arguments":{}}}'
+```
+
+- `list_apps`（可选过滤）
+```bash
+curl -X POST http://127.0.0.1:27190/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":9,"method":"tools/call","params":{"name":"list_apps","arguments":{"query":"auto","includeSystem":false,"limit":50}}}'
+```
+
+- `save_script`（保存到 AutoJs 默认脚本目录）
+```bash
+curl -X POST http://127.0.0.1:27190/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":10,"method":"tools/call","params":{"name":"save_script","arguments":{"name":"kuaishou_automation.js","script":"toast(\\"hello\\")","overwrite":true}}}'
+```
+
+- `run_script_file`（运行脚本目录下文件或绝对路径）
+```bash
+curl -X POST http://127.0.0.1:27190/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":11,"method":"tools/call","params":{"name":"run_script_file","arguments":{"path":"kuaishou_automation.js"}}}'
+```
+
+- `list_scripts`（列出脚本目录）
+```bash
+curl -X POST http://127.0.0.1:27190/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":12,"method":"tools/call","params":{"name":"list_scripts","arguments":{"query":"kuaishou","limit":50,"recursive":true}}}'
+```
+
+- `list_script_dirs`（列出脚本目录下的子目录）
+```bash
+curl -X POST http://127.0.0.1:27190/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":13,"method":"tools/call","params":{"name":"list_script_dirs","arguments":{"recursive":true,"limit":50}}}'
+```
+
+- `list_samples`（列出内置示例脚本）
+```bash
+curl -X POST http://127.0.0.1:27190/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":13,"method":"tools/call","params":{"name":"list_samples","arguments":{"query":"OCR","limit":20}}}'
+```
+
+- `read_sample`（读取内置示例脚本）
+```bash
+curl -X POST http://127.0.0.1:27190/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":14,"method":"tools/call","params":{"name":"read_sample","arguments":{"path":"v6/GoogleMLKit/OCR识别点击.js"}}}'
+```
+
+- `read_script`（读取脚本内容）
+```bash
+curl -X POST http://127.0.0.1:27190/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":14,"method":"tools/call","params":{"name":"read_script","arguments":{"path":"kuaishou_automation.js"}}}'
+```
+
+- `update_script`（覆盖脚本内容）
+```bash
+curl -X POST http://127.0.0.1:27190/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":15,"method":"tools/call","params":{"name":"update_script","arguments":{"path":"kuaishou_automation.js","script":"toast(\\"updated\\")"}}}'
+```
+
+- `rename_script`（重命名脚本）
+```bash
+curl -X POST http://127.0.0.1:27190/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":16,"method":"tools/call","params":{"name":"rename_script","arguments":{"path":"kuaishou_automation.js","newName":"kuaishou_final.js"}}}'
+```
+
+- `delete_script`（删除脚本）
+```bash
+curl -X POST http://127.0.0.1:27190/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":17,"method":"tools/call","params":{"name":"delete_script","arguments":{"path":"kuaishou_final.js"}}}'
+```
+
+- `find_elements`（批量查找 UI 节点）
+```bash
+curl -X POST http://127.0.0.1:27190/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":18,"method":"tools/call","params":{"name":"find_elements","arguments":{"text":"关注","limit":5}}}'
+```
+
+- `get_foreground_app` / `get_current_activity`
+```bash
+curl -X POST http://127.0.0.1:27190/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":19,"method":"tools/call","params":{"name":"get_foreground_app","arguments":{}}}'
+```
+
+```bash
+curl -X POST http://127.0.0.1:27190/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":20,"method":"tools/call","params":{"name":"get_current_activity","arguments":{}}}'
+```
+- `get_ui_tree`（紧凑格式）
+返回字段说明：
+- `c`: 简化类名
+- `id`: resource id（可选）
+- `t`: text（可选）
+- `d`: contentDescription（可选）
+- `p`: packageName（仅在与父节点不同或根节点时出现）
+- `b`: bounds 数组 `[left, top, right, bottom]`
+- `a`: 交互标记字符串（`c`=clickable, `f`=focusable, `s`=scrollable, `l`=longClickable, `d`=disabled）
+- `children`: 子节点数组（无子节点时省略）
+说明：默认仅保留“可交互/有文本/有描述/有 id”的节点，以及它们的直接父节点（用于保持一层结构）。
+
+> 已接入自动化实现，如需扩展可在 `McpService.registerDefaultTools` 中注册更多工具。
+
+## 打包与构建
+- 模块已加入 `settings.gradle.kts`，并在 `app/build.gradle.kts` 依赖 `project(":mcp")`，常规 `app:assembleV7Debug` / `app:assembleV7` 会自动包含。
+- 单独构建：`./gradlew :mcp:assembleDebug`
+- 环境要求：JDK 17、Android SDK 34 + build-tools 34.0.0（已写入 `local.properties`）。
+
+## 开发提示
+- 服务默认监听 `0.0.0.0:27190`（允许局域网访问）；如需仅本机访问可改为 `127.0.0.1`，并务必设置 `token`。
+- 运行脚本使用 `EngineController` 调度，脚本执行完后会删除临时文件。
+- 占位工具返回 `NotImplemented`，可按 `DefaultTools.kt` 模式补齐，建议统一输入校验与超时控制。
+- 工具调用日志：Logcat 过滤 `McpToolCall`（服务运行在 `:script` 进程）。
+- `get_recent_screenshot` 在无历史截图时会自动抓取一张。
+- Base64 截图默认会缩放到最长边 720px，并使用 JPEG 质量 70 以降低体积。
+- `save_script` 会写入 AutoJs 当前脚本目录（对应应用设置里的“脚本路径”）。
+- `list_samples` / `read_sample` 读取 AutoJs 内置示例资源（assets/sample）。
+- `read_script` / `update_script` / `delete_script` / `rename_script` 仅操作脚本目录内文件（按相对路径解析）。
+- `run_script_file` 会从 AutoJs 当前脚本目录解析相对路径，或接受绝对路径。
+- `list_scripts` 返回脚本目录内的脚本文件列表（相对路径）。
+- `list_script_dirs` 返回脚本目录内的子目录列表（相对路径）。

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,6 +19,9 @@
 #systemProp.https.proxyHost=127.0.0.1
 #systemProp.http.proxyPort=1080
 org.gradle.jvmargs=-Xmx4096m  -Dfile.encoding=UTF-8
+org.gradle.java.home=C\:\\tools\\jdk17\\jdk-17.0.13+11
+org.gradle.java.installations.paths=C\:\\tools\\jdk17\\jdk-17.0.13+11
+org.gradle.java.installations.auto-download=true
 org.gradle.daemon=true
 org.gradle.parallel=true
 org.gradle.configureondemand=true

--- a/mcp/build.gradle.kts
+++ b/mcp/build.gradle.kts
@@ -1,0 +1,42 @@
+plugins {
+    id("com.android.library")
+    id("kotlin-android")
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(versions.javaVersionInt))
+    }
+}
+
+android {
+    namespace = "org.autojs.autoxjs.mcp"
+    compileSdk = versions.compile
+
+    defaultConfig {
+        minSdk = versions.mini
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    buildFeatures {
+        buildConfig = true
+    }
+
+    lint {
+        abortOnError = false
+    }
+}
+
+dependencies {
+    implementation(platform(libs.compose.bom))
+    implementation(libs.kotlinx.coroutines.android)
+    implementation(libs.google.gson)
+    implementation(libs.bundles.ktor)
+    implementation(libs.appcompat)
+    implementation(libs.core.ktx)
+    implementation(libs.preference.ktx)
+    implementation(project(":autojs"))
+    testImplementation(libs.junit)
+    androidTestImplementation(libs.androidx.test.ext.junit)
+    androidTestImplementation(libs.espresso.core)
+}

--- a/mcp/src/main/AndroidManifest.xml
+++ b/mcp/src/main/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application>
+        <service
+            android:name=".McpServerService"
+            android:exported="false"
+            android:foregroundServiceType="dataSync"
+            android:process=":script" />
+    </application>
+</manifest>

--- a/mcp/src/main/java/org/autojs/autoxjs/mcp/McpConfig.kt
+++ b/mcp/src/main/java/org/autojs/autoxjs/mcp/McpConfig.kt
@@ -1,0 +1,13 @@
+package org.autojs.autoxjs.mcp
+
+/**
+ * Configuration for the MCP in-app server.
+ */
+data class McpConfig(
+    val enabled: Boolean = false,
+    val host: String = "0.0.0.0",
+    val port: Int = 27190,
+    val token: String? = null,
+    val allowBase64: Boolean = false,
+    val allowNetwork: Boolean = true
+)

--- a/mcp/src/main/java/org/autojs/autoxjs/mcp/McpJsonRpcHandler.kt
+++ b/mcp/src/main/java/org/autojs/autoxjs/mcp/McpJsonRpcHandler.kt
@@ -1,0 +1,208 @@
+package org.autojs.autoxjs.mcp
+
+import android.util.Log
+import com.google.gson.Gson
+import com.google.gson.JsonArray
+import com.google.gson.JsonElement
+import com.google.gson.JsonNull
+import com.google.gson.JsonObject
+import com.google.gson.JsonParser
+import io.ktor.http.HttpStatusCode
+import org.autojs.autoxjs.mcp.tool.ToolDefinition
+import org.autojs.autoxjs.mcp.tool.ToolRegistry
+
+data class McpServerInfo(
+    val name: String,
+    val title: String? = null,
+    val version: String? = null,
+    val description: String? = null
+)
+
+data class RpcHttpResponse(
+    val status: HttpStatusCode,
+    val body: JsonObject? = null
+)
+
+class McpJsonRpcHandler(
+    private val registry: ToolRegistry,
+    private val serverInfoProvider: () -> McpServerInfo,
+    private val protocolVersion: String = PROTOCOL_VERSION
+) {
+    private val gson = Gson()
+
+    suspend fun handleText(body: String): RpcHttpResponse {
+        val json = try {
+            JsonParser.parseString(body)
+        } catch (e: Exception) {
+            return RpcHttpResponse(
+                HttpStatusCode.BadRequest,
+                errorResponse(null, -32700, "Parse error")
+            )
+        }
+        if (!json.isJsonObject) {
+            return RpcHttpResponse(
+                HttpStatusCode.BadRequest,
+                errorResponse(null, -32600, "Invalid Request")
+            )
+        }
+        return handleJson(json.asJsonObject)
+    }
+
+    suspend fun handleJson(json: JsonObject): RpcHttpResponse {
+        val jsonrpc = json.get("jsonrpc")?.takeIf { it.isJsonPrimitive && it.asJsonPrimitive.isString }?.asString
+        if (jsonrpc != "2.0") {
+            return RpcHttpResponse(HttpStatusCode.BadRequest, errorResponse(null, -32600, "Invalid Request"))
+        }
+
+        val methodElement = json.get("method")
+        val idElement = json.get("id")
+
+        if (methodElement == null) {
+            val hasResultOrError = json.has("result") || json.has("error")
+            return if (hasResultOrError) {
+                RpcHttpResponse(HttpStatusCode.Accepted)
+            } else {
+                RpcHttpResponse(HttpStatusCode.BadRequest, errorResponse(null, -32600, "Invalid Request"))
+            }
+        }
+
+        if (!methodElement.isJsonPrimitive || !methodElement.asJsonPrimitive.isString) {
+            return RpcHttpResponse(HttpStatusCode.BadRequest, errorResponse(null, -32600, "Invalid Request"))
+        }
+
+        val method = methodElement.asString
+        val params = json.get("params")
+
+        if (idElement == null || idElement.isJsonNull) {
+            handleNotification(method, params)
+            return RpcHttpResponse(HttpStatusCode.Accepted)
+        }
+
+        val response = handleRequest(method, idElement, params)
+        return RpcHttpResponse(HttpStatusCode.OK, response)
+    }
+
+    private fun handleNotification(method: String, params: JsonElement?) {
+        when (method) {
+            "notifications/initialized" -> Unit
+            else -> Unit
+        }
+    }
+
+    private suspend fun handleRequest(method: String, id: JsonElement, params: JsonElement?): JsonObject {
+        return when (method) {
+            "initialize" -> handleInitialize(id, params)
+            "ping" -> successResponse(id, JsonObject())
+            "tools/list" -> handleToolsList(id, params)
+            "tools/call" -> handleToolsCall(id, params)
+            else -> errorResponse(id, -32601, "Method not found")
+        }
+    }
+
+    private fun handleInitialize(id: JsonElement, params: JsonElement?): JsonObject {
+        if (params == null || !params.isJsonObject) {
+            return errorResponse(id, -32602, "Invalid params")
+        }
+        val clientVersion = params.asJsonObject.get("protocolVersion")
+            ?.takeIf { it.isJsonPrimitive && it.asJsonPrimitive.isString }
+            ?.asString
+        val info = serverInfoProvider()
+        val result = JsonObject().apply {
+            addProperty("protocolVersion", clientVersion ?: protocolVersion)
+            add("capabilities", JsonObject().apply {
+                add("tools", JsonObject().apply {
+                    addProperty("listChanged", false)
+                })
+            })
+            add("serverInfo", JsonObject().apply {
+                addProperty("name", info.name)
+                info.title?.let { addProperty("title", it) }
+                info.version?.let { addProperty("version", it) }
+                info.description?.let { addProperty("description", it) }
+            })
+        }
+        return successResponse(id, result)
+    }
+
+    private fun handleToolsList(id: JsonElement, params: JsonElement?): JsonObject {
+        if (params != null && !params.isJsonObject) {
+            return errorResponse(id, -32602, "Invalid params")
+        }
+        val toolsJson = JsonArray()
+        registry.definitions().forEach { toolsJson.add(toolToJson(it)) }
+        val result = JsonObject().apply {
+            add("tools", toolsJson)
+        }
+        return successResponse(id, result)
+    }
+
+    private suspend fun handleToolsCall(id: JsonElement, params: JsonElement?): JsonObject {
+        if (params == null || !params.isJsonObject) {
+            return errorResponse(id, -32602, "Invalid params")
+        }
+        val paramsObj = params.asJsonObject
+        val name = paramsObj.get("name")?.takeIf { it.isJsonPrimitive && it.asJsonPrimitive.isString }?.asString
+            ?: return errorResponse(id, -32602, "Invalid params")
+        val args = when {
+            paramsObj.get("arguments") == null -> JsonObject()
+            paramsObj.get("arguments").isJsonObject -> paramsObj.get("arguments").asJsonObject
+            else -> return errorResponse(id, -32602, "Invalid params")
+        }
+
+        Log.i(TAG, "tools/call id=$id name=$name argsKeys=${args.keySet().joinToString(",")}")
+        val response = registry.invoke(name, args)
+        Log.i(TAG, "tools/call id=$id name=$name ok=${response.ok} error=${response.errorCode}")
+        val content = JsonArray()
+        val text = if (response.ok) {
+            response.data?.let { data ->
+                if (data is String) data else gson.toJson(data)
+            } ?: "ok"
+        } else {
+            response.errorMessage ?: response.errorCode ?: "error"
+        }
+        content.add(JsonObject().apply {
+            addProperty("type", "text")
+            addProperty("text", text)
+        })
+
+        val result = JsonObject().apply {
+            add("content", content)
+            addProperty("isError", !response.ok)
+        }
+        return successResponse(id, result)
+    }
+
+    private fun toolToJson(definition: ToolDefinition): JsonObject {
+        return JsonObject().apply {
+            addProperty("name", definition.name)
+            definition.title?.let { addProperty("title", it) }
+            addProperty("description", definition.description)
+            add("inputSchema", definition.inputSchema)
+            definition.outputSchema?.let { add("outputSchema", it) }
+        }
+    }
+
+    private fun successResponse(id: JsonElement, result: JsonObject): JsonObject {
+        return JsonObject().apply {
+            addProperty("jsonrpc", "2.0")
+            add("id", id)
+            add("result", result)
+        }
+    }
+
+    private fun errorResponse(id: JsonElement?, code: Int, message: String): JsonObject {
+        return JsonObject().apply {
+            addProperty("jsonrpc", "2.0")
+            add("id", id ?: JsonNull.INSTANCE)
+            add("error", JsonObject().apply {
+                addProperty("code", code)
+                addProperty("message", message)
+            })
+        }
+    }
+
+    companion object {
+        const val PROTOCOL_VERSION = "2025-11-25"
+        private const val TAG = "McpToolCall"
+    }
+}

--- a/mcp/src/main/java/org/autojs/autoxjs/mcp/McpPrefKeys.kt
+++ b/mcp/src/main/java/org/autojs/autoxjs/mcp/McpPrefKeys.kt
@@ -1,0 +1,10 @@
+package org.autojs.autoxjs.mcp
+
+object McpPrefKeys {
+    const val KEY_ENABLED = "key_mcp_enabled"
+    const val KEY_HOST = "key_mcp_host"
+    const val KEY_PORT = "key_mcp_port"
+    const val KEY_TOKEN = "key_mcp_token"
+    const val KEY_ALLOW_BASE64 = "key_mcp_allow_base64"
+    const val KEY_ALLOW_NETWORK = "key_mcp_allow_network"
+}

--- a/mcp/src/main/java/org/autojs/autoxjs/mcp/McpPrefs.kt
+++ b/mcp/src/main/java/org/autojs/autoxjs/mcp/McpPrefs.kt
@@ -1,0 +1,42 @@
+package org.autojs.autoxjs.mcp
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.preference.PreferenceManager
+
+object McpPrefs {
+    private const val DEFAULT_HOST = "0.0.0.0"
+    private const val LOCAL_HOST = "127.0.0.1"
+    private const val DEFAULT_PORT = 27190
+    private val LOCAL_HOSTS = setOf(LOCAL_HOST, "localhost", "::1")
+
+    @Suppress("DEPRECATION")
+    private fun getSharedPreferences(context: Context): SharedPreferences {
+        val name = context.packageName + "_preferences"
+        return context.getSharedPreferences(name, Context.MODE_MULTI_PROCESS)
+    }
+
+    fun load(context: Context): McpConfig {
+        val prefs = getSharedPreferences(context)
+        val enabled = prefs.getBoolean(McpPrefKeys.KEY_ENABLED, false)
+        val allowBase64 = prefs.getBoolean(McpPrefKeys.KEY_ALLOW_BASE64, false)
+        val host = prefs.getString(McpPrefKeys.KEY_HOST, DEFAULT_HOST).orEmpty().ifBlank { DEFAULT_HOST }
+        val allowNetworkPref = prefs.getBoolean(McpPrefKeys.KEY_ALLOW_NETWORK, true)
+        val allowNetwork = allowNetworkPref || !LOCAL_HOSTS.contains(host)
+        val port = prefs.getString(McpPrefKeys.KEY_PORT, DEFAULT_PORT.toString())
+            ?.toIntOrNull()
+            ?.coerceIn(1, 65535)
+            ?: DEFAULT_PORT
+        val token = prefs.getString(McpPrefKeys.KEY_TOKEN, null)?.trim().orEmpty().ifBlank { null }
+        val finalHost = if (allowNetwork) host else LOCAL_HOST
+
+        return McpConfig(
+            enabled = enabled,
+            host = finalHost,
+            port = port,
+            token = token,
+            allowBase64 = allowBase64,
+            allowNetwork = allowNetwork
+        )
+    }
+}

--- a/mcp/src/main/java/org/autojs/autoxjs/mcp/McpResponse.kt
+++ b/mcp/src/main/java/org/autojs/autoxjs/mcp/McpResponse.kt
@@ -1,0 +1,16 @@
+package org.autojs.autoxjs.mcp
+
+/**
+ * Standardized response envelope for MCP tools.
+ */
+data class McpResponse(
+    val ok: Boolean,
+    val data: Any? = null,
+    val errorCode: String? = null,
+    val errorMessage: String? = null
+) {
+    companion object {
+        fun ok(data: Any? = null) = McpResponse(true, data, null, null)
+        fun error(code: String, message: String) = McpResponse(false, null, code, message)
+    }
+}

--- a/mcp/src/main/java/org/autojs/autoxjs/mcp/McpRuntimeProvider.kt
+++ b/mcp/src/main/java/org/autojs/autoxjs/mcp/McpRuntimeProvider.kt
@@ -1,0 +1,33 @@
+package org.autojs.autoxjs.mcp
+
+import com.stardust.autojs.AutoJs
+import com.stardust.autojs.runtime.ScriptRuntimeV2
+
+class McpRuntimeProvider {
+    private val lock = Any()
+    private var runtime: ScriptRuntimeV2? = null
+
+    fun getRuntime(): ScriptRuntimeV2 {
+        synchronized(lock) {
+            val current = runtime
+            if (current != null) {
+                return current
+            }
+            val autoJs = try {
+                AutoJs.instance
+            } catch (e: UninitializedPropertyAccessException) {
+                throw IllegalStateException("AutoJs is not initialized", e)
+            }
+            val created = autoJs.createRuntimeBuilder().build().apply { init() }
+            runtime = created
+            return created
+        }
+    }
+
+    fun close() {
+        synchronized(lock) {
+            runtime?.onExit()
+            runtime = null
+        }
+    }
+}

--- a/mcp/src/main/java/org/autojs/autoxjs/mcp/McpServer.kt
+++ b/mcp/src/main/java/org/autojs/autoxjs/mcp/McpServer.kt
@@ -1,0 +1,160 @@
+package org.autojs.autoxjs.mcp
+
+import android.content.Context
+import android.content.pm.PackageInfo
+import android.net.Uri
+import android.util.Log
+import com.google.gson.Gson
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.call
+import io.ktor.server.application.install
+import io.ktor.server.engine.ApplicationEngine
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.netty.Netty
+import io.ktor.server.request.receiveText
+import io.ktor.server.response.respond
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.post
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
+import io.ktor.server.websocket.WebSockets
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import org.autojs.autoxjs.mcp.tool.ToolRegistry
+import java.net.NetworkInterface
+
+/**
+ * Lightweight MCP server wrapper based on Ktor.
+ */
+class McpServer(
+    private val appContext: Context,
+    private val registry: ToolRegistry
+) {
+    private val gson = Gson()
+    private var engine: ApplicationEngine? = null
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val jsonRpcHandler = McpJsonRpcHandler(
+        registry,
+        serverInfoProvider = { buildServerInfo() }
+    )
+
+    val isRunning: Boolean
+        get() = engine?.application?.environment?.monitor != null
+
+    fun start(config: McpConfig) {
+        stop()
+        if (!config.enabled) return
+        engine = embeddedServer(Netty, port = config.port, host = config.host) {
+            install(WebSockets)
+            routing {
+                post("/mcp") {
+                    if (!isOriginAllowed(config, call.request.headers["Origin"])) {
+                        call.respond(
+                            HttpStatusCode.Forbidden
+                        )
+                        return@post
+                    }
+
+                    if (!authorize(config, call.request.headers["X-Token"])) {
+                        call.respond(HttpStatusCode.Unauthorized)
+                        return@post
+                    }
+
+                    val body = call.receiveText()
+                    val response = jsonRpcHandler.handleText(body)
+                    if (response.body == null) {
+                        call.respond(response.status)
+                    } else {
+                        call.respondText(
+                            gson.toJson(response.body),
+                            ContentType.Application.Json,
+                            response.status
+                        )
+                    }
+                }
+
+                get("/mcp") {
+                    call.respond(HttpStatusCode.MethodNotAllowed)
+                }
+
+            }
+        }.also { engine -> engine.start(wait = false) }
+        Log.i(TAG, "MCP server started on ${config.host}:${config.port}")
+    }
+
+    fun stop() {
+        try {
+            engine?.stop(1000, 2000)
+        } catch (e: Exception) {
+            Log.e(TAG, "Error stopping server", e)
+        } finally {
+            engine = null
+        }
+    }
+
+    private fun authorize(config: McpConfig, tokenHeader: String?): Boolean {
+        val expected = config.token
+        return expected.isNullOrBlank() || expected == tokenHeader
+    }
+
+    private fun isOriginAllowed(config: McpConfig, originHeader: String?): Boolean {
+        if (originHeader.isNullOrBlank()) {
+            return true
+        }
+        val host = try {
+            Uri.parse(originHeader).host
+        } catch (_: Exception) {
+            null
+        } ?: return false
+
+        val allowedHosts = if (config.allowNetwork) {
+            localHosts()
+        } else {
+            setOf("localhost", "127.0.0.1", "::1")
+        }
+        return allowedHosts.contains(host)
+    }
+
+    private fun localHosts(): Set<String> {
+        val hosts = mutableSetOf("localhost", "127.0.0.1", "::1")
+        try {
+            val interfaces = NetworkInterface.getNetworkInterfaces()
+            while (interfaces.hasMoreElements()) {
+                val iface = interfaces.nextElement()
+                val addresses = iface.inetAddresses
+                while (addresses.hasMoreElements()) {
+                    val address = addresses.nextElement()
+                    val host = address.hostAddress?.substringBefore('%')
+                    if (!host.isNullOrBlank()) {
+                        hosts.add(host)
+                    }
+                }
+            }
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to resolve local addresses", e)
+        }
+        return hosts
+    }
+
+    private fun buildServerInfo(): McpServerInfo {
+        val name = "AutoX MCP"
+        val versionName = try {
+            val info: PackageInfo = appContext.packageManager.getPackageInfo(appContext.packageName, 0)
+            info.versionName
+        } catch (_: Exception) {
+            null
+        }
+        return McpServerInfo(
+            name = name,
+            title = name,
+            version = versionName,
+            description = "AutoX embedded MCP tools server"
+        )
+    }
+
+    companion object {
+        private const val TAG = "McpServer"
+    }
+}

--- a/mcp/src/main/java/org/autojs/autoxjs/mcp/McpServerService.kt
+++ b/mcp/src/main/java/org/autojs/autoxjs/mcp/McpServerService.kt
@@ -1,0 +1,128 @@
+package org.autojs.autoxjs.mcp
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.SharedPreferences
+import android.os.Build
+import android.os.IBinder
+import androidx.core.app.NotificationCompat
+import androidx.core.content.ContextCompat
+import androidx.preference.PreferenceManager
+
+class McpServerService : Service(), SharedPreferences.OnSharedPreferenceChangeListener {
+    private lateinit var prefs: SharedPreferences
+    private lateinit var mcpService: McpService
+    @Volatile
+    private var foregroundStarted = false
+
+    override fun onCreate() {
+        super.onCreate()
+        startForegroundIfNeeded()
+        @Suppress("DEPRECATION")
+        prefs = getSharedPreferences(
+            packageName + "_preferences",
+            Context.MODE_MULTI_PROCESS
+        )
+        prefs.registerOnSharedPreferenceChangeListener(this)
+        mcpService = McpService(this)
+        applyConfig()
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        startForegroundIfNeeded()
+        applyConfig()
+        return START_STICKY
+    }
+
+    override fun onDestroy() {
+        prefs.unregisterOnSharedPreferenceChangeListener(this)
+        mcpService.stop()
+        stopForeground(STOP_FOREGROUND_REMOVE)
+        foregroundStarted = false
+        super.onDestroy()
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences?, key: String?) {
+        if (key in MCP_KEYS) {
+            applyConfig()
+        }
+    }
+
+    private fun applyConfig() {
+        val config = McpPrefs.load(this)
+        if (config.enabled) {
+            startForegroundIfNeeded()
+            mcpService.start(config)
+        } else {
+            mcpService.stop()
+            stopForeground(STOP_FOREGROUND_REMOVE)
+            foregroundStarted = false
+            stopSelf()
+        }
+    }
+
+    private fun startForegroundIfNeeded() {
+        if (foregroundStarted) {
+            return
+        }
+        val notification = buildNotification()
+        startForeground(NOTIFICATION_ID, notification)
+        foregroundStarted = true
+    }
+
+    private fun buildNotification(): Notification {
+        val channelId = ensureChannel()
+        return NotificationCompat.Builder(this, channelId)
+            .setSmallIcon(android.R.drawable.stat_notify_sync)
+            .setContentTitle(getString(R.string.mcp_notification_title))
+            .setContentText(getString(R.string.mcp_notification_text))
+            .setOngoing(true)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .build()
+    }
+
+    private fun ensureChannel(): String {
+        val channelId = CHANNEL_ID
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val manager = getSystemService(NotificationManager::class.java)
+            val channel = NotificationChannel(
+                channelId,
+                getString(R.string.mcp_notification_channel_name),
+                NotificationManager.IMPORTANCE_LOW
+            )
+            channel.description = getString(R.string.mcp_notification_channel_desc)
+            manager.createNotificationChannel(channel)
+        }
+        return channelId
+    }
+
+    companion object {
+        private const val CHANNEL_ID = "mcp_server"
+        private const val NOTIFICATION_ID = 27190
+
+        private val MCP_KEYS = setOf(
+            McpPrefKeys.KEY_ENABLED,
+            McpPrefKeys.KEY_HOST,
+            McpPrefKeys.KEY_PORT,
+            McpPrefKeys.KEY_TOKEN,
+            McpPrefKeys.KEY_ALLOW_BASE64,
+            McpPrefKeys.KEY_ALLOW_NETWORK
+        )
+
+        fun start(context: Context) {
+            val intent = Intent(context, McpServerService::class.java)
+            ContextCompat.startForegroundService(context, intent)
+        }
+
+        fun stop(context: Context) {
+            val intent = Intent(context, McpServerService::class.java)
+            context.stopService(intent)
+        }
+    }
+}

--- a/mcp/src/main/java/org/autojs/autoxjs/mcp/McpService.kt
+++ b/mcp/src/main/java/org/autojs/autoxjs/mcp/McpService.kt
@@ -1,0 +1,457 @@
+package org.autojs.autoxjs.mcp
+
+import android.content.Context
+import android.util.Log
+import org.autojs.autoxjs.mcp.tool.ToolDefinition
+import org.autojs.autoxjs.mcp.tool.ToolRegistry
+import org.autojs.autoxjs.mcp.tool.ToolSchemas
+import org.autojs.autoxjs.mcp.tools.AppControlTool
+import org.autojs.autoxjs.mcp.tools.CancelJobTool
+import org.autojs.autoxjs.mcp.tools.DeleteScriptTool
+import org.autojs.autoxjs.mcp.tools.DeviceInfoTool
+import org.autojs.autoxjs.mcp.tools.FindElementTool
+import org.autojs.autoxjs.mcp.tools.FindElementsTool
+import org.autojs.autoxjs.mcp.tools.GetCurrentActivityTool
+import org.autojs.autoxjs.mcp.tools.GetForegroundAppTool
+import org.autojs.autoxjs.mcp.tools.GetRecentScreenshotTool
+import org.autojs.autoxjs.mcp.tools.GetUiTreeTool
+import org.autojs.autoxjs.mcp.tools.JobStatusTool
+import org.autojs.autoxjs.mcp.tools.JobTracker
+import org.autojs.autoxjs.mcp.tools.ListAppsTool
+import org.autojs.autoxjs.mcp.tools.ListSamplesTool
+import org.autojs.autoxjs.mcp.tools.ListScriptDirsTool
+import org.autojs.autoxjs.mcp.tools.ListScriptsTool
+import org.autojs.autoxjs.mcp.tools.LogsTool
+import org.autojs.autoxjs.mcp.tools.McpToolContext
+import org.autojs.autoxjs.mcp.tools.OcrTool
+import org.autojs.autoxjs.mcp.tools.ReadSampleTool
+import org.autojs.autoxjs.mcp.tools.ReadScriptTool
+import org.autojs.autoxjs.mcp.tools.RenameScriptTool
+import org.autojs.autoxjs.mcp.tools.RunScriptTool
+import org.autojs.autoxjs.mcp.tools.RunScriptFileTool
+import org.autojs.autoxjs.mcp.tools.SaveScriptTool
+import org.autojs.autoxjs.mcp.tools.ScreenshotTool
+import org.autojs.autoxjs.mcp.tools.SwipeTool
+import org.autojs.autoxjs.mcp.tools.TapTool
+import org.autojs.autoxjs.mcp.tools.UpdateScriptTool
+
+/**
+ * Facade to start/stop MCP server with default tools registered.
+ */
+class McpService(private val context: Context) {
+    private val tracker = JobTracker()
+    private val registry = ToolRegistry()
+    private val runtimeProvider = McpRuntimeProvider()
+    private val screenshotStore = ScreenshotStore()
+    @Volatile
+    private var currentConfig: McpConfig = McpConfig()
+    private val toolContext = McpToolContext(
+        appContext = context.applicationContext,
+        runtimeProvider = runtimeProvider,
+        screenshotStore = screenshotStore
+    ) { currentConfig }
+    private var server: McpServer? = null
+
+    init {
+        registerDefaultTools()
+    }
+
+    fun start(config: McpConfig) {
+        currentConfig = config
+        if (!config.enabled) {
+            stop()
+            return
+        }
+        if (server == null) {
+            server = McpServer(context.applicationContext, registry)
+        }
+        server?.start(config)
+        Log.i(TAG, "MCP service started")
+    }
+
+    fun stop() {
+        server?.stop()
+        runtimeProvider.close()
+        Log.i(TAG, "MCP service stopped")
+    }
+
+    private fun registerDefaultTools() {
+        registry.apply {
+            register(
+                ToolDefinition(
+                    name = "device_info",
+                    title = "Device Info",
+                    description = "Return device information and locale.",
+                    inputSchema = ToolSchemas.emptyObject()
+                ),
+                DeviceInfoTool()
+            )
+            register(
+                ToolDefinition(
+                    name = "run_script",
+                    title = "Run Script",
+                    description = "Run an AutoJs script and return a job id.",
+                    inputSchema = ToolSchemas.objectSchema(
+                        mapOf(
+                            "script" to ToolSchemas.stringSchema("JavaScript source to execute."),
+                            "name" to ToolSchemas.stringSchema("Optional job name."),
+                            "mode" to ToolSchemas.stringSchema("Optional runtime mode."),
+                            "timeoutMillis" to ToolSchemas.intSchema("Optional timeout in milliseconds.")
+                        ),
+                        required = listOf("script")
+                    )
+                ),
+                RunScriptTool(context, tracker)
+            )
+            register(
+                ToolDefinition(
+                    name = "job_status",
+                    title = "Job Status",
+                    description = "Get status for a script job.",
+                    inputSchema = ToolSchemas.objectSchema(
+                        mapOf("jobId" to ToolSchemas.intSchema("Job id.")),
+                        required = listOf("jobId")
+                    )
+                ),
+                JobStatusTool(tracker)
+            )
+            register(
+                ToolDefinition(
+                    name = "cancel_job",
+                    title = "Cancel Job",
+                    description = "Cancel a running job.",
+                    inputSchema = ToolSchemas.objectSchema(
+                        mapOf("jobId" to ToolSchemas.intSchema("Job id.")),
+                        required = listOf("jobId")
+                    )
+                ),
+                CancelJobTool(tracker)
+            )
+            register(
+                ToolDefinition(
+                    name = "logs",
+                    title = "Logs",
+                    description = "Get recent job logs.",
+                    inputSchema = ToolSchemas.objectSchema(
+                        mapOf("recent" to ToolSchemas.intSchema("Max number of log entries.")),
+                        required = emptyList()
+                    )
+                ),
+                LogsTool(tracker)
+            )
+            register(
+                ToolDefinition(
+                    name = "list_apps",
+                    title = "List Apps",
+                    description = "List installed apps with optional filtering.",
+                    inputSchema = ToolSchemas.objectSchema(
+                        mapOf(
+                            "query" to ToolSchemas.stringSchema("Filter by package name or label."),
+                            "includeSystem" to ToolSchemas.booleanSchema("Include system apps."),
+                            "limit" to ToolSchemas.intSchema("Max number of results.")
+                        )
+                    )
+                ),
+                ListAppsTool(context)
+            )
+            register(
+                ToolDefinition(
+                    name = "save_script",
+                    title = "Save Script",
+                    description = "Save a script file into AutoJs default scripts directory.",
+                    inputSchema = ToolSchemas.objectSchema(
+                        mapOf(
+                            "script" to ToolSchemas.stringSchema("JavaScript source to save."),
+                            "name" to ToolSchemas.stringSchema("Optional script file name."),
+                            "overwrite" to ToolSchemas.booleanSchema("Overwrite if file exists.")
+                        ),
+                        required = listOf("script")
+                    )
+                ),
+                SaveScriptTool(context)
+            )
+            register(
+                ToolDefinition(
+                    name = "list_samples",
+                    title = "List Samples",
+                    description = "List built-in sample scripts shipped with AutoJs.",
+                    inputSchema = ToolSchemas.objectSchema(
+                        mapOf(
+                            "query" to ToolSchemas.stringSchema("Filter by sample path or name."),
+                            "limit" to ToolSchemas.intSchema("Max number of results.")
+                        )
+                    )
+                ),
+                ListSamplesTool(context)
+            )
+            register(
+                ToolDefinition(
+                    name = "read_sample",
+                    title = "Read Sample",
+                    description = "Read a built-in sample script by path.",
+                    inputSchema = ToolSchemas.objectSchema(
+                        mapOf(
+                            "path" to ToolSchemas.stringSchema("Sample path under assets/sample.")
+                        ),
+                        required = listOf("path")
+                    )
+                ),
+                ReadSampleTool(context)
+            )
+            register(
+                ToolDefinition(
+                    name = "read_script",
+                    title = "Read Script",
+                    description = "Read a script file from AutoJs scripts directory.",
+                    inputSchema = ToolSchemas.objectSchema(
+                        mapOf(
+                            "path" to ToolSchemas.stringSchema("Script file path relative to scripts dir.")
+                        ),
+                        required = listOf("path")
+                    )
+                ),
+                ReadScriptTool(context)
+            )
+            register(
+                ToolDefinition(
+                    name = "update_script",
+                    title = "Update Script",
+                    description = "Overwrite an existing script file in AutoJs scripts directory.",
+                    inputSchema = ToolSchemas.objectSchema(
+                        mapOf(
+                            "path" to ToolSchemas.stringSchema("Script file path relative to scripts dir."),
+                            "script" to ToolSchemas.stringSchema("JavaScript source to save.")
+                        ),
+                        required = listOf("path", "script")
+                    )
+                ),
+                UpdateScriptTool(context)
+            )
+            register(
+                ToolDefinition(
+                    name = "delete_script",
+                    title = "Delete Script",
+                    description = "Delete a script file from AutoJs scripts directory.",
+                    inputSchema = ToolSchemas.objectSchema(
+                        mapOf(
+                            "path" to ToolSchemas.stringSchema("Script file path relative to scripts dir.")
+                        ),
+                        required = listOf("path")
+                    )
+                ),
+                DeleteScriptTool(context)
+            )
+            register(
+                ToolDefinition(
+                    name = "rename_script",
+                    title = "Rename Script",
+                    description = "Rename a script file in AutoJs scripts directory.",
+                    inputSchema = ToolSchemas.objectSchema(
+                        mapOf(
+                            "path" to ToolSchemas.stringSchema("Script file path relative to scripts dir."),
+                            "newName" to ToolSchemas.stringSchema("New script file name.")
+                        ),
+                        required = listOf("path", "newName")
+                    )
+                ),
+                RenameScriptTool(context)
+            )
+            register(
+                ToolDefinition(
+                    name = "run_script_file",
+                    title = "Run Script File",
+                    description = "Run a script file from AutoJs scripts directory or absolute path.",
+                    inputSchema = ToolSchemas.objectSchema(
+                        mapOf(
+                            "path" to ToolSchemas.stringSchema("Script file path or name under scripts dir."),
+                            "name" to ToolSchemas.stringSchema("Optional job name.")
+                        ),
+                        required = listOf("path")
+                    )
+                ),
+                RunScriptFileTool(context, tracker)
+            )
+            register(
+                ToolDefinition(
+                    name = "list_scripts",
+                    title = "List Scripts",
+                    description = "List scripts from AutoJs scripts directory.",
+                    inputSchema = ToolSchemas.objectSchema(
+                        mapOf(
+                            "query" to ToolSchemas.stringSchema("Filter by file name or path."),
+                            "limit" to ToolSchemas.intSchema("Max number of results."),
+                            "recursive" to ToolSchemas.booleanSchema("List subdirectories.")
+                        )
+                    )
+                ),
+                ListScriptsTool(context)
+            )
+            register(
+                ToolDefinition(
+                    name = "list_script_dirs",
+                    title = "List Script Dirs",
+                    description = "List directories under AutoJs scripts directory.",
+                    inputSchema = ToolSchemas.objectSchema(
+                        mapOf(
+                            "query" to ToolSchemas.stringSchema("Filter by directory name or path."),
+                            "limit" to ToolSchemas.intSchema("Max number of results."),
+                            "recursive" to ToolSchemas.booleanSchema("List subdirectories.")
+                        )
+                    )
+                ),
+                ListScriptDirsTool(context)
+            )
+            register(
+                ToolDefinition(
+                    name = "tap",
+                    title = "Tap",
+                    description = "Tap on screen at the given coordinates.",
+                    inputSchema = ToolSchemas.objectSchema(
+                        mapOf(
+                            "x" to ToolSchemas.intSchema("X coordinate."),
+                            "y" to ToolSchemas.intSchema("Y coordinate.")
+                        ),
+                        required = listOf("x", "y")
+                    )
+                ),
+                TapTool(toolContext)
+            )
+            register(
+                ToolDefinition(
+                    name = "swipe",
+                    title = "Swipe",
+                    description = "Swipe from one coordinate to another.",
+                    inputSchema = ToolSchemas.objectSchema(
+                        mapOf(
+                            "x1" to ToolSchemas.intSchema("Start X coordinate."),
+                            "y1" to ToolSchemas.intSchema("Start Y coordinate."),
+                            "x2" to ToolSchemas.intSchema("End X coordinate."),
+                            "y2" to ToolSchemas.intSchema("End Y coordinate."),
+                            "duration" to ToolSchemas.intSchema("Duration in milliseconds.")
+                        ),
+                        required = listOf("x1", "y1", "x2", "y2")
+                    )
+                ),
+                SwipeTool(toolContext)
+            )
+            register(
+                ToolDefinition(
+                    name = "find_element",
+                    title = "Find Element",
+                    description = "Find a UI element by text, id, desc, or className.",
+                    inputSchema = ToolSchemas.objectSchema(
+                        mapOf(
+                            "text" to ToolSchemas.stringSchema("Match element text."),
+                            "id" to ToolSchemas.stringSchema("Match resource id."),
+                            "desc" to ToolSchemas.stringSchema("Match content description."),
+                            "className" to ToolSchemas.stringSchema("Match class name."),
+                            "timeoutMillis" to ToolSchemas.intSchema("Search timeout in milliseconds.")
+                        )
+                    )
+                ),
+                FindElementTool(toolContext)
+            )
+            register(
+                ToolDefinition(
+                    name = "find_elements",
+                    title = "Find Elements",
+                    description = "Find multiple UI elements by text, id, desc, or className.",
+                    inputSchema = ToolSchemas.objectSchema(
+                        mapOf(
+                            "text" to ToolSchemas.stringSchema("Match element text."),
+                            "id" to ToolSchemas.stringSchema("Match resource id."),
+                            "desc" to ToolSchemas.stringSchema("Match content description."),
+                            "className" to ToolSchemas.stringSchema("Match class name."),
+                            "timeoutMillis" to ToolSchemas.intSchema("Search timeout in milliseconds."),
+                            "limit" to ToolSchemas.intSchema("Max number of results.")
+                        )
+                    )
+                ),
+                FindElementsTool(toolContext)
+            )
+            register(
+                ToolDefinition(
+                    name = "screenshot",
+                    title = "Screenshot",
+                    description = "Capture a screenshot and store it on device.",
+                    inputSchema = ToolSchemas.objectSchema(
+                        mapOf("asBase64" to ToolSchemas.booleanSchema("Include base64 in response."))
+                    )
+                ),
+                ScreenshotTool(toolContext)
+            )
+            register(
+                ToolDefinition(
+                    name = "ocr",
+                    title = "OCR",
+                    description = "Run OCR on a screenshot or image file.",
+                    inputSchema = ToolSchemas.objectSchema(
+                        mapOf(
+                            "source" to ToolSchemas.stringSchema("Use 'screenshot' for last screenshot."),
+                            "path" to ToolSchemas.stringSchema("Absolute file path to image."),
+                            "language" to ToolSchemas.stringSchema("OCR language code.")
+                        )
+                    )
+                ),
+                OcrTool(toolContext)
+            )
+            register(
+                ToolDefinition(
+                    name = "app_control",
+                    title = "App Control",
+                    description = "Launch or force-stop an app.",
+                    inputSchema = ToolSchemas.objectSchema(
+                        mapOf(
+                            "action" to ToolSchemas.stringSchema("launch | bring_to_front | force_stop"),
+                            "packageName" to ToolSchemas.stringSchema("Target package name.")
+                        ),
+                        required = listOf("action", "packageName")
+                    )
+                ),
+                AppControlTool(toolContext)
+            )
+            register(
+                ToolDefinition(
+                    name = "get_foreground_app",
+                    title = "Get Foreground App",
+                    description = "Get the foreground package name.",
+                    inputSchema = ToolSchemas.emptyObject()
+                ),
+                GetForegroundAppTool(toolContext)
+            )
+            register(
+                ToolDefinition(
+                    name = "get_current_activity",
+                    title = "Get Current Activity",
+                    description = "Get the current activity class name.",
+                    inputSchema = ToolSchemas.emptyObject()
+                ),
+                GetCurrentActivityTool(toolContext)
+            )
+            register(
+                ToolDefinition(
+                    name = "get_ui_tree",
+                    title = "Get UI Tree",
+                    description = "Capture the current UI tree.",
+                    inputSchema = ToolSchemas.emptyObject()
+                ),
+                GetUiTreeTool(toolContext)
+            )
+            register(
+                ToolDefinition(
+                    name = "get_recent_screenshot",
+                    title = "Get Recent Screenshot",
+                    description = "Return metadata (and optional base64) of the most recent screenshot.",
+                    inputSchema = ToolSchemas.objectSchema(
+                        mapOf("asBase64" to ToolSchemas.booleanSchema("Include base64 in response."))
+                    )
+                ),
+                GetRecentScreenshotTool(toolContext)
+            )
+        }
+    }
+
+    companion object {
+        private const val TAG = "McpService"
+    }
+}

--- a/mcp/src/main/java/org/autojs/autoxjs/mcp/ScreenshotStore.kt
+++ b/mcp/src/main/java/org/autojs/autoxjs/mcp/ScreenshotStore.kt
@@ -1,0 +1,19 @@
+package org.autojs.autoxjs.mcp
+
+data class ScreenshotInfo(
+    val path: String,
+    val width: Int,
+    val height: Int,
+    val timestamp: Long
+)
+
+class ScreenshotStore {
+    @Volatile
+    private var last: ScreenshotInfo? = null
+
+    fun update(info: ScreenshotInfo) {
+        last = info
+    }
+
+    fun get(): ScreenshotInfo? = last
+}

--- a/mcp/src/main/java/org/autojs/autoxjs/mcp/tool/McpTool.kt
+++ b/mcp/src/main/java/org/autojs/autoxjs/mcp/tool/McpTool.kt
@@ -1,0 +1,11 @@
+package org.autojs.autoxjs.mcp.tool
+
+import com.google.gson.JsonObject
+import org.autojs.autoxjs.mcp.McpResponse
+
+/**
+ * A single MCP tool handler.
+ */
+fun interface McpTool {
+    suspend fun handle(params: JsonObject?): McpResponse
+}

--- a/mcp/src/main/java/org/autojs/autoxjs/mcp/tool/ToolDefinition.kt
+++ b/mcp/src/main/java/org/autojs/autoxjs/mcp/tool/ToolDefinition.kt
@@ -1,0 +1,11 @@
+package org.autojs.autoxjs.mcp.tool
+
+import com.google.gson.JsonObject
+
+data class ToolDefinition(
+    val name: String,
+    val title: String?,
+    val description: String,
+    val inputSchema: JsonObject,
+    val outputSchema: JsonObject? = null
+)

--- a/mcp/src/main/java/org/autojs/autoxjs/mcp/tool/ToolRegistry.kt
+++ b/mcp/src/main/java/org/autojs/autoxjs/mcp/tool/ToolRegistry.kt
@@ -1,0 +1,44 @@
+package org.autojs.autoxjs.mcp.tool
+
+import com.google.gson.JsonObject
+import org.autojs.autoxjs.mcp.McpResponse
+import java.util.concurrent.ConcurrentHashMap
+
+class ToolRegistry {
+    private data class Entry(
+        val definition: ToolDefinition?,
+        val tool: McpTool
+    )
+
+    private val tools = ConcurrentHashMap<String, Entry>()
+
+    fun register(name: String, tool: McpTool) {
+        tools[name] = Entry(null, tool)
+    }
+
+    fun register(definition: ToolDefinition, tool: McpTool) {
+        tools[definition.name] = Entry(definition, tool)
+    }
+
+    fun names(): Set<String> = tools.keys
+
+    fun definitions(): List<ToolDefinition> {
+        return tools.entries.map { (name, entry) ->
+            entry.definition ?: ToolDefinition(
+                name = name,
+                title = null,
+                description = "Tool $name",
+                inputSchema = ToolSchemas.emptyObject()
+            )
+        }.sortedBy { it.name }
+    }
+
+    suspend fun invoke(name: String, params: JsonObject?): McpResponse {
+        val entry = tools[name] ?: return McpResponse.error("NotFound", "Tool `$name` not registered")
+        return try {
+            entry.tool.handle(params)
+        } catch (e: Exception) {
+            McpResponse.error("Internal", e.message ?: "Internal error")
+        }
+    }
+}

--- a/mcp/src/main/java/org/autojs/autoxjs/mcp/tool/ToolSchemas.kt
+++ b/mcp/src/main/java/org/autojs/autoxjs/mcp/tool/ToolSchemas.kt
@@ -1,0 +1,61 @@
+package org.autojs.autoxjs.mcp.tool
+
+import com.google.gson.JsonArray
+import com.google.gson.JsonObject
+
+object ToolSchemas {
+    fun emptyObject(): JsonObject {
+        return JsonObject().apply {
+            addProperty("type", "object")
+            addProperty("additionalProperties", false)
+        }
+    }
+
+    fun objectSchema(
+        properties: Map<String, JsonObject>,
+        required: List<String> = emptyList(),
+        additionalProperties: Boolean = false
+    ): JsonObject {
+        val schema = JsonObject()
+        schema.addProperty("type", "object")
+        val props = JsonObject()
+        for ((key, value) in properties) {
+            props.add(key, value)
+        }
+        schema.add("properties", props)
+        if (required.isNotEmpty()) {
+            val req = JsonArray()
+            required.forEach { req.add(it) }
+            schema.add("required", req)
+        }
+        schema.addProperty("additionalProperties", additionalProperties)
+        return schema
+    }
+
+    fun stringSchema(description: String? = null): JsonObject {
+        return JsonObject().apply {
+            addProperty("type", "string")
+            if (!description.isNullOrBlank()) {
+                addProperty("description", description)
+            }
+        }
+    }
+
+    fun intSchema(description: String? = null): JsonObject {
+        return JsonObject().apply {
+            addProperty("type", "integer")
+            if (!description.isNullOrBlank()) {
+                addProperty("description", description)
+            }
+        }
+    }
+
+    fun booleanSchema(description: String? = null): JsonObject {
+        return JsonObject().apply {
+            addProperty("type", "boolean")
+            if (!description.isNullOrBlank()) {
+                addProperty("description", description)
+            }
+        }
+    }
+}

--- a/mcp/src/main/java/org/autojs/autoxjs/mcp/tools/AutomationTools.kt
+++ b/mcp/src/main/java/org/autojs/autoxjs/mcp/tools/AutomationTools.kt
@@ -1,0 +1,542 @@
+package org.autojs.autoxjs.mcp.tools
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.os.Build
+import android.os.SystemClock
+import com.google.gson.Gson
+import com.google.gson.JsonObject
+import com.stardust.autojs.core.accessibility.UiSelector
+import com.stardust.autojs.core.image.ImageWrapper
+import com.stardust.autojs.runtime.ScriptRuntimeV2
+import com.stardust.autojs.runtime.api.Images
+import com.stardust.autojs.AutoJs
+import com.stardust.view.accessibility.LayoutInspector
+import com.stardust.view.accessibility.NodeInfo
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+import org.autojs.autoxjs.mcp.McpConfig
+import org.autojs.autoxjs.mcp.McpResponse
+import org.autojs.autoxjs.mcp.McpRuntimeProvider
+import org.autojs.autoxjs.mcp.ScreenshotInfo
+import org.autojs.autoxjs.mcp.ScreenshotStore
+import org.autojs.autoxjs.mcp.tool.McpTool
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.util.concurrent.TimeUnit
+
+private val gson = Gson()
+
+data class McpToolContext(
+    val appContext: Context,
+    val runtimeProvider: McpRuntimeProvider,
+    val screenshotStore: ScreenshotStore,
+    val configProvider: () -> McpConfig
+)
+
+data class TapRequest(val x: Int, val y: Int)
+data class SwipeRequest(val x1: Int, val y1: Int, val x2: Int, val y2: Int, val duration: Int? = 300)
+data class FindElementRequest(
+    val text: String? = null,
+    val id: String? = null,
+    val desc: String? = null,
+    val className: String? = null,
+    val timeoutMillis: Long? = 2000
+)
+data class FindElementsRequest(
+    val text: String? = null,
+    val id: String? = null,
+    val desc: String? = null,
+    val className: String? = null,
+    val timeoutMillis: Long? = 2000,
+    val limit: Int? = 20
+)
+data class ScreenshotRequest(val asBase64: Boolean? = false)
+data class GetRecentScreenshotRequest(val asBase64: Boolean? = false)
+data class OcrRequest(val source: String? = null, val path: String? = null, val language: String? = "zh")
+data class AppControlRequest(val action: String, val packageName: String)
+
+class TapTool(private val ctx: McpToolContext) : McpTool {
+    override suspend fun handle(params: JsonObject?): McpResponse {
+        val req = parse(params, TapRequest::class.java)
+            ?: return McpResponse.error("BadRequest", "x/y required")
+        val runtime = ctx.runtimeProvider.getRuntime()
+        return try {
+            val ok = runtime.automator.click(req.x, req.y)
+            if (ok) McpResponse.ok(mapOf("ok" to true)) else McpResponse.error("Failed", "tap failed")
+        } catch (e: Exception) {
+            McpResponse.error("Failed", e.message ?: "tap failed")
+        }
+    }
+}
+
+class SwipeTool(private val ctx: McpToolContext) : McpTool {
+    override suspend fun handle(params: JsonObject?): McpResponse {
+        val req = parse(params, SwipeRequest::class.java)
+            ?: return McpResponse.error("BadRequest", "x1/y1/x2/y2 required")
+        val runtime = ctx.runtimeProvider.getRuntime()
+        val duration = req.duration ?: 300
+        return try {
+            val ok = runtime.automator.swipe(req.x1, req.y1, req.x2, req.y2, duration)
+            if (ok) McpResponse.ok(mapOf("ok" to true)) else McpResponse.error("Failed", "swipe failed")
+        } catch (e: Exception) {
+            McpResponse.error("Failed", e.message ?: "swipe failed")
+        }
+    }
+}
+
+class FindElementTool(private val ctx: McpToolContext) : McpTool {
+    override suspend fun handle(params: JsonObject?): McpResponse {
+        val req = parse(params, FindElementRequest::class.java) ?: FindElementRequest()
+        if (req.text.isNullOrBlank() && req.id.isNullOrBlank() && req.desc.isNullOrBlank() && req.className.isNullOrBlank()) {
+            return McpResponse.error("BadRequest", "criteria required")
+        }
+        val runtime = ctx.runtimeProvider.getRuntime()
+        val selector = runtime.selector()
+        applySelector(selector, req.text, req.id, req.desc, req.className)
+        return try {
+            val timeout = req.timeoutMillis ?: 2000
+            val obj = selector.findOne(timeout)
+            if (obj == null) {
+                McpResponse.error("NotFound", "element not found")
+            } else {
+                val rect = obj.bounds()
+                val data = mapOf(
+                    "bounds" to mapOf("left" to rect.left, "top" to rect.top, "right" to rect.right, "bottom" to rect.bottom),
+                    "center" to mapOf("x" to rect.centerX(), "y" to rect.centerY()),
+                    "text" to obj.text(),
+                    "id" to obj.id(),
+                    "desc" to obj.desc(),
+                    "className" to obj.className(),
+                    "packageName" to obj.packageName()
+                )
+                McpResponse.ok(data)
+            }
+        } catch (e: Exception) {
+            McpResponse.error("Failed", e.message ?: "find_element failed")
+        }
+    }
+}
+
+class FindElementsTool(private val ctx: McpToolContext) : McpTool {
+    override suspend fun handle(params: JsonObject?): McpResponse {
+        val req = parse(params, FindElementsRequest::class.java) ?: FindElementsRequest()
+        if (req.text.isNullOrBlank() && req.id.isNullOrBlank() && req.desc.isNullOrBlank() && req.className.isNullOrBlank()) {
+            return McpResponse.error("BadRequest", "criteria required")
+        }
+        val runtime = ctx.runtimeProvider.getRuntime()
+        val selector = runtime.selector()
+        applySelector(selector, req.text, req.id, req.desc, req.className)
+        return try {
+            val timeout = req.timeoutMillis ?: 2000
+            val limit = req.limit?.takeIf { it > 0 } ?: 20
+            val collection = findCollectionWithTimeout(selector, timeout)
+            if (collection.isEmpty) {
+                return McpResponse.ok(mapOf("count" to 0, "elements" to emptyList<Map<String, Any>>()))
+            }
+            val results = ArrayList<Map<String, Any?>>(minOf(limit, collection.size()))
+            for (obj in collection) {
+                if (obj == null) {
+                    continue
+                }
+                val rect = obj.bounds()
+                results.add(
+                    mapOf(
+                        "bounds" to mapOf(
+                            "left" to rect.left,
+                            "top" to rect.top,
+                            "right" to rect.right,
+                            "bottom" to rect.bottom
+                        ),
+                        "center" to mapOf("x" to rect.centerX(), "y" to rect.centerY()),
+                        "text" to obj.text(),
+                        "id" to obj.id(),
+                        "desc" to obj.desc(),
+                        "className" to obj.className(),
+                        "packageName" to obj.packageName()
+                    )
+                )
+                if (results.size >= limit) {
+                    break
+                }
+            }
+            McpResponse.ok(mapOf("count" to results.size, "elements" to results))
+        } catch (e: Exception) {
+            McpResponse.error("Failed", e.message ?: "find_elements failed")
+        }
+    }
+}
+
+class GetForegroundAppTool(private val ctx: McpToolContext) : McpTool {
+    override suspend fun handle(params: JsonObject?): McpResponse {
+        val runtime = ctx.runtimeProvider.getRuntime()
+        val info = runtime.info
+        val packageName = info.getLatestPackageByUsageStatsIfGranted()
+            .takeIf { it.isNotBlank() }
+            ?: info.latestPackage
+        if (packageName.isBlank()) {
+            return McpResponse.error("NotFound", "foreground app not found")
+        }
+        val pm = ctx.appContext.packageManager
+        val label = try {
+            val appInfo = pm.getApplicationInfo(packageName, 0)
+            pm.getApplicationLabel(appInfo)?.toString() ?: packageName
+        } catch (_: Exception) {
+            packageName
+        }
+        val activity = info.latestActivity.takeIf { it.isNotBlank() }
+        return McpResponse.ok(
+            mapOf(
+                "packageName" to packageName,
+                "label" to label,
+                "activity" to activity
+            )
+        )
+    }
+}
+
+class GetCurrentActivityTool(private val ctx: McpToolContext) : McpTool {
+    override suspend fun handle(params: JsonObject?): McpResponse {
+        val runtime = ctx.runtimeProvider.getRuntime()
+        val info = runtime.info
+        val activity = info.latestActivity.takeIf { it.isNotBlank() }
+            ?: return McpResponse.error("NotFound", "activity not found")
+        val packageName = info.getLatestPackageByUsageStatsIfGranted()
+            .takeIf { it.isNotBlank() }
+            ?: info.latestPackage
+        return McpResponse.ok(
+            mapOf(
+                "activity" to activity,
+                "packageName" to packageName
+            )
+        )
+    }
+}
+
+class ScreenshotTool(private val ctx: McpToolContext) : McpTool {
+    override suspend fun handle(params: JsonObject?): McpResponse {
+        val req = parse(params, ScreenshotRequest::class.java) ?: ScreenshotRequest()
+        val runtime = ctx.runtimeProvider.getRuntime()
+        return try {
+            val image = captureImage(runtime)
+            val file = saveImage(ctx.appContext, image)
+            val info = ScreenshotInfo(
+                path = file.absolutePath,
+                width = image.width,
+                height = image.height,
+                timestamp = System.currentTimeMillis()
+            )
+            ctx.screenshotStore.update(info)
+            val data = if (req.asBase64 == true) {
+                if (!ctx.configProvider().allowBase64) {
+                    return McpResponse.error("Forbidden", "base64 disabled by config")
+                }
+                mapOf(
+                    "path" to info.path,
+                    "width" to info.width,
+                    "height" to info.height,
+                    "timestamp" to info.timestamp,
+                    "base64" to imageToBase64(image)
+                )
+            } else {
+                mapOf(
+                    "path" to info.path,
+                    "width" to info.width,
+                    "height" to info.height,
+                    "timestamp" to info.timestamp
+                )
+            }
+            image.recycle()
+            McpResponse.ok(data)
+        } catch (e: Exception) {
+            McpResponse.error("Failed", e.message ?: "screenshot failed")
+        }
+    }
+}
+
+class GetRecentScreenshotTool(private val ctx: McpToolContext) : McpTool {
+    override suspend fun handle(params: JsonObject?): McpResponse {
+        val req = parse(params, GetRecentScreenshotRequest::class.java) ?: GetRecentScreenshotRequest()
+        var info = ctx.screenshotStore.get()
+        var captured: ImageWrapper? = null
+        if (info == null) {
+            val runtime = ctx.runtimeProvider.getRuntime()
+            try {
+                val image = captureImage(runtime)
+                val file = saveImage(ctx.appContext, image)
+                info = ScreenshotInfo(
+                    path = file.absolutePath,
+                    width = image.width,
+                    height = image.height,
+                    timestamp = System.currentTimeMillis()
+                )
+                ctx.screenshotStore.update(info)
+                captured = image
+            } catch (e: Exception) {
+                captured?.recycle()
+                return McpResponse.error("Failed", e.message ?: "screenshot failed")
+            }
+        }
+        val data = mutableMapOf<String, Any>(
+            "path" to info.path,
+            "width" to info.width,
+            "height" to info.height,
+            "timestamp" to info.timestamp
+        )
+        if (req.asBase64 == true) {
+            if (!ctx.configProvider().allowBase64) {
+                captured?.recycle()
+                return McpResponse.error("Forbidden", "base64 disabled by config")
+            }
+            val base64 = if (captured != null) {
+                imageToBase64(captured)
+            } else {
+                val bitmap = BitmapFactory.decodeFile(info.path)
+                    ?: return McpResponse.error("Failed", "image decode failed")
+                val image = ImageWrapper.ofBitmap(bitmap)
+                val encoded = imageToBase64(image)
+                image.recycle()
+                encoded
+            }
+            data["base64"] = base64
+        }
+        captured?.recycle()
+        return McpResponse.ok(data)
+    }
+}
+
+class OcrTool(private val ctx: McpToolContext) : McpTool {
+    override suspend fun handle(params: JsonObject?): McpResponse {
+        val req = parse(params, OcrRequest::class.java) ?: OcrRequest()
+        val runtime = ctx.runtimeProvider.getRuntime()
+        var image: ImageWrapper? = null
+        return try {
+            image = when {
+                req.path?.isNotBlank() == true -> {
+                    val bitmap = BitmapFactory.decodeFile(req.path)
+                        ?: return McpResponse.error("Failed", "image decode failed")
+                    ImageWrapper.ofBitmap(bitmap)
+                }
+                req.source?.lowercase() == "screenshot" -> {
+                    val captured = captureImage(runtime)
+                    val file = saveImage(ctx.appContext, captured)
+                    val info = ScreenshotInfo(
+                        path = file.absolutePath,
+                        width = captured.width,
+                        height = captured.height,
+                        timestamp = System.currentTimeMillis()
+                    )
+                    ctx.screenshotStore.update(info)
+                    captured
+                }
+                else -> null
+            } ?: return McpResponse.error("BadRequest", "path or source required")
+
+            val language = req.language ?: "zh"
+            val result = runtime.gmlkit.ocr(image, language)
+            if (result != null) McpResponse.ok(result) else McpResponse.error("Failed", "ocr failed")
+        } catch (e: Exception) {
+            McpResponse.error("Failed", e.message ?: "ocr failed")
+        } finally {
+            image?.recycle()
+        }
+    }
+}
+
+class AppControlTool(private val ctx: McpToolContext) : McpTool {
+    override suspend fun handle(params: JsonObject?): McpResponse {
+        val req = parse(params, AppControlRequest::class.java)
+            ?: return McpResponse.error("BadRequest", "action/packageName required")
+        val runtime = ctx.runtimeProvider.getRuntime()
+        return when (req.action.lowercase()) {
+            "launch", "bring_to_front" -> {
+                val ok = runtime.app.launchPackage(req.packageName)
+                if (ok) McpResponse.ok(mapOf("ok" to true)) else McpResponse.error("Failed", "launch failed")
+            }
+            "force_stop" -> {
+                val result = runtime.shell.exec("am force-stop ${req.packageName}", false)
+                if (result.code == 0) McpResponse.ok(mapOf("ok" to true)) else McpResponse.error(
+                    "Failed",
+                    "force_stop failed: ${result.error}"
+                )
+            }
+            else -> McpResponse.error("BadRequest", "unsupported action")
+        }
+    }
+}
+
+class GetUiTreeTool(private val ctx: McpToolContext) : McpTool {
+    override suspend fun handle(params: JsonObject?): McpResponse {
+        return try {
+            val inspector = AutoJs.instance.layoutInspector
+            val capture = captureLayout(inspector)
+            val data = capture?.let { root ->
+                val nodes = buildCompactNodes(root, null, true)
+                nodes.firstOrNull()
+            } ?: return McpResponse.error("Failed", "capture failed")
+            McpResponse.ok(data)
+        } catch (e: Exception) {
+            McpResponse.error("Failed", e.message ?: "capture failed")
+        }
+    }
+}
+
+private suspend fun captureLayout(inspector: LayoutInspector): NodeInfo? {
+    val deferred = CompletableDeferred<NodeInfo?>()
+    val listener = object : LayoutInspector.CaptureAvailableListener {
+        override fun onCaptureAvailable(capture: NodeInfo?) {
+            inspector.removeCaptureAvailableListener(this)
+            deferred.complete(capture)
+        }
+    }
+    inspector.addCaptureAvailableListener(listener)
+    if (!inspector.captureCurrentWindow()) {
+        inspector.removeCaptureAvailableListener(listener)
+        return null
+    }
+    return withTimeoutOrNull(TimeUnit.SECONDS.toMillis(3)) { deferred.await() }
+}
+
+private fun buildCompactNodes(node: NodeInfo, parentPackage: String?, isRoot: Boolean): List<Map<String, Any?>> {
+    val bounds = node.boundsInScreen
+    val data = LinkedHashMap<String, Any?>()
+
+    val hasSignal = hasNodeSignal(node)
+
+    val className = node.className?.toString()?.substringAfterLast('.')?.takeIf { it.isNotBlank() }
+        ?: node.className?.toString()
+    if (!className.isNullOrBlank()) {
+        data["c"] = className
+    }
+
+    if (hasSignal || isRoot) {
+        node.id?.takeIf { it.isNotBlank() }?.let { data["id"] = it }
+        node.text?.toString()?.takeIf { it.isNotBlank() }?.let { data["t"] = it }
+        node.desc?.toString()?.takeIf { it.isNotBlank() }?.let { data["d"] = it }
+    }
+
+    val pkg = node.packageName?.toString()?.takeIf { it.isNotBlank() }
+    if (pkg != null && pkg != parentPackage) {
+        data["p"] = pkg
+    }
+
+    data["b"] = listOf(bounds.left, bounds.top, bounds.right, bounds.bottom)
+
+    val flags = StringBuilder()
+    if (node.clickable) flags.append('c')
+    if (node.focusable) flags.append('f')
+    if (node.scrollable) flags.append('s')
+    if (node.longClickable) flags.append('l')
+    if (!node.enabled) flags.append('d')
+    if (flags.isNotEmpty() && (hasSignal || isRoot)) {
+        data["a"] = flags.toString()
+    }
+
+    val nextParent = pkg ?: parentPackage
+    val children = node.getChildren()
+    val hasDirectSignalChild = children.any { hasNodeSignal(it) }
+    val keptChildren = children.flatMap { buildCompactNodes(it, nextParent, false) }
+
+    val keepNode = isRoot || hasSignal || hasDirectSignalChild
+    if (keepNode) {
+        if (keptChildren.isNotEmpty()) {
+            data["children"] = keptChildren
+        }
+        return listOf(data)
+    }
+    return keptChildren
+}
+
+private fun hasNodeSignal(node: NodeInfo): Boolean {
+    if (node.clickable || node.focusable || node.scrollable || node.longClickable) {
+        return true
+    }
+    if (!node.text?.toString().isNullOrBlank()) {
+        return true
+    }
+    if (!node.desc?.toString().isNullOrBlank()) {
+        return true
+    }
+    if (!node.id.isNullOrBlank()) {
+        return true
+    }
+    return false
+}
+
+private fun applySelector(
+    selector: UiSelector,
+    text: String?,
+    id: String?,
+    desc: String?,
+    className: String?
+) {
+    text?.takeIf { it.isNotBlank() }?.let { selector.text(it) }
+    id?.takeIf { it.isNotBlank() }?.let { selector.id(it) }
+    desc?.takeIf { it.isNotBlank() }?.let { selector.desc(it) }
+    className?.takeIf { it.isNotBlank() }?.let { selector.className(it) }
+}
+
+private fun findCollectionWithTimeout(selector: UiSelector, timeoutMillis: Long): com.stardust.automator.UiObjectCollection {
+    if (timeoutMillis <= 0) {
+        return selector.find()
+    }
+    val start = SystemClock.uptimeMillis()
+    var collection = selector.find()
+    while (collection.isEmpty && SystemClock.uptimeMillis() - start < timeoutMillis) {
+        Thread.sleep(50)
+        collection = selector.find()
+    }
+    return collection
+}
+
+private fun <T> parse(params: JsonObject?, clazz: Class<T>): T? {
+    return try {
+        if (params == null) null else gson.fromJson(params, clazz)
+    } catch (_: Exception) {
+        null
+    }
+}
+
+private fun captureImage(runtime: ScriptRuntimeV2): ImageWrapper {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+        return runtime.automator.takeScreenshot2Sync()
+    }
+    @Suppress("UNCHECKED_CAST")
+    val images = runtime.images as Images
+    return images.captureScreen()
+}
+
+private suspend fun saveImage(context: Context, image: ImageWrapper): File = withContext(Dispatchers.IO) {
+    val file = File(context.cacheDir, "mcp-screenshot-${System.currentTimeMillis()}.png")
+    image.saveTo(file.absolutePath)
+    file
+}
+
+private fun imageToBase64(image: ImageWrapper): String {
+    val output = ByteArrayOutputStream()
+    val source = image.bitmap
+    val scaled = scaleBitmapIfNeeded(source, BASE64_MAX_DIMENSION)
+    val target = scaled ?: source
+    target.compress(Bitmap.CompressFormat.JPEG, BASE64_JPEG_QUALITY, output)
+    scaled?.recycle()
+    return android.util.Base64.encodeToString(output.toByteArray(), android.util.Base64.NO_WRAP)
+}
+
+private fun scaleBitmapIfNeeded(source: Bitmap, maxDimension: Int): Bitmap? {
+    val width = source.width
+    val height = source.height
+    val maxSide = maxOf(width, height)
+    if (maxSide <= maxDimension) {
+        return null
+    }
+    val scale = maxDimension.toFloat() / maxSide.toFloat()
+    val targetWidth = (width * scale).toInt().coerceAtLeast(1)
+    val targetHeight = (height * scale).toInt().coerceAtLeast(1)
+    return Bitmap.createScaledBitmap(source, targetWidth, targetHeight, true)
+}
+
+private const val BASE64_MAX_DIMENSION = 720
+private const val BASE64_JPEG_QUALITY = 70

--- a/mcp/src/main/java/org/autojs/autoxjs/mcp/tools/DefaultTools.kt
+++ b/mcp/src/main/java/org/autojs/autoxjs/mcp/tools/DefaultTools.kt
@@ -1,0 +1,744 @@
+package org.autojs.autoxjs.mcp.tools
+
+import android.content.Context
+import android.content.pm.ApplicationInfo
+import android.os.Build
+import android.os.Environment
+import androidx.preference.PreferenceManager
+import org.autojs.autoxjs.mcp.McpResponse
+import org.autojs.autoxjs.mcp.tool.McpTool
+import com.google.gson.Gson
+import com.google.gson.JsonObject
+import com.stardust.autojs.servicecomponents.BinderScriptListener
+import com.stardust.autojs.servicecomponents.EngineController
+import java.io.File
+import java.util.ArrayDeque
+import java.util.Locale
+
+private val gson = Gson()
+
+data class RunScriptRequest(
+    val script: String,
+    val name: String? = null,
+    val mode: String? = null,
+    val timeoutMillis: Long? = null
+)
+
+data class ListAppsRequest(
+    val query: String? = null,
+    val includeSystem: Boolean? = false,
+    val limit: Int? = null
+)
+
+data class SaveScriptRequest(
+    val script: String,
+    val name: String? = null,
+    val overwrite: Boolean? = false
+)
+
+data class RunScriptFileRequest(
+    val path: String,
+    val name: String? = null
+)
+
+data class ListScriptsRequest(
+    val query: String? = null,
+    val limit: Int? = null,
+    val recursive: Boolean? = false
+)
+
+data class ListSamplesRequest(
+    val query: String? = null,
+    val limit: Int? = null
+)
+
+data class ReadSampleRequest(
+    val path: String
+)
+
+data class ReadScriptRequest(
+    val path: String
+)
+
+data class UpdateScriptRequest(
+    val path: String,
+    val script: String
+)
+
+data class DeleteScriptRequest(
+    val path: String
+)
+
+data class RenameScriptRequest(
+    val path: String,
+    val newName: String
+)
+
+data class ListScriptDirsRequest(
+    val query: String? = null,
+    val limit: Int? = null,
+    val recursive: Boolean? = false
+)
+
+class DeviceInfoTool : McpTool {
+    override suspend fun handle(params: JsonObject?): McpResponse {
+        val locale = Locale.getDefault()
+        val data = mapOf(
+            "manufacturer" to Build.MANUFACTURER,
+            "model" to Build.MODEL,
+            "sdkInt" to Build.VERSION.SDK_INT,
+            "device" to Build.DEVICE,
+            "locale" to locale.toLanguageTag()
+        )
+        return McpResponse.ok(data)
+    }
+}
+
+class RunScriptTool(
+    private val appContext: Context,
+    private val tracker: JobTracker
+) : McpTool {
+    override suspend fun handle(params: JsonObject?): McpResponse {
+        val request = try {
+            gson.fromJson(params, RunScriptRequest::class.java)
+        } catch (e: Exception) {
+            return McpResponse.error("BadRequest", "Invalid request: ${e.message}")
+        }
+        if (request.script.isBlank()) {
+            return McpResponse.error("BadRequest", "script is required")
+        }
+        val job = tracker.newJob(request.name ?: "script")
+        val tmp = File(appContext.cacheDir, "mcp-${job.jobId}-${request.name ?: "script"}.js")
+        tmp.writeText(request.script)
+        val listener = object : BinderScriptListener {
+            override fun onStart(taskInfo: com.stardust.autojs.servicecomponents.TaskInfo) {
+                tracker.update(job.jobId, JobStatus.Status.RUNNING, "started")
+            }
+
+            override fun onSuccess(taskInfo: com.stardust.autojs.servicecomponents.TaskInfo) {
+                tracker.update(job.jobId, JobStatus.Status.SUCCESS, "completed")
+                tmp.delete()
+            }
+
+            override fun onException(taskInfo: com.stardust.autojs.servicecomponents.TaskInfo, e: Throwable) {
+                tracker.update(job.jobId, JobStatus.Status.FAILED, e.message)
+                tmp.delete()
+            }
+        }
+        EngineController.runScript(tmp, listener, null)
+        return McpResponse.ok(mapOf("jobId" to job.jobId))
+    }
+}
+
+class JobStatusTool(
+    private val tracker: JobTracker
+) : McpTool {
+    override suspend fun handle(params: JsonObject?): McpResponse {
+        val jobId = params?.get("jobId")?.asInt
+            ?: return McpResponse.error("BadRequest", "jobId is required")
+        val status = tracker.get(jobId) ?: return McpResponse.error("NotFound", "job not found")
+        return McpResponse.ok(status)
+    }
+}
+
+class CancelJobTool(
+    private val tracker: JobTracker
+) : McpTool {
+    override suspend fun handle(params: JsonObject?): McpResponse {
+        val jobId = params?.get("jobId")?.asInt
+            ?: return McpResponse.error("BadRequest", "jobId is required")
+        tracker.update(jobId, JobStatus.Status.CANCELED, "requested cancel")
+        // Fallback: stop all scripts if needed (coarse-grained).
+        EngineController.stopAllScript()
+        return McpResponse.ok(mapOf("jobId" to jobId, "status" to "CANCELED"))
+    }
+}
+
+class LogsTool(
+    private val tracker: JobTracker
+) : McpTool {
+    override suspend fun handle(params: JsonObject?): McpResponse {
+        val recent = params?.get("recent")?.asInt ?: 20
+        return McpResponse.ok(tracker.recent(recent))
+    }
+}
+
+class ListAppsTool(
+    private val appContext: Context
+) : McpTool {
+    override suspend fun handle(params: JsonObject?): McpResponse {
+        val request = try {
+            if (params == null) ListAppsRequest() else gson.fromJson(params, ListAppsRequest::class.java)
+        } catch (e: Exception) {
+            return McpResponse.error("BadRequest", "Invalid request: ${e.message}")
+        }
+        val query = request.query?.trim()?.lowercase(Locale.getDefault())
+        val includeSystem = request.includeSystem == true
+        val limit = request.limit?.takeIf { it > 0 } ?: Int.MAX_VALUE
+        val pm = appContext.packageManager
+        val apps = pm.getInstalledApplications(0)
+        val results = ArrayList<Map<String, Any>>(apps.size.coerceAtMost(limit))
+        for (app in apps) {
+            if (!includeSystem && (app.flags and ApplicationInfo.FLAG_SYSTEM) != 0) {
+                continue
+            }
+            val label = app.loadLabel(pm)?.toString() ?: app.packageName
+            if (!query.isNullOrEmpty()) {
+                val match = label.lowercase(Locale.getDefault()).contains(query) ||
+                    app.packageName.lowercase(Locale.getDefault()).contains(query)
+                if (!match) {
+                    continue
+                }
+            }
+            results.add(
+                mapOf(
+                    "packageName" to app.packageName,
+                    "label" to label,
+                    "enabled" to app.enabled,
+                    "system" to ((app.flags and ApplicationInfo.FLAG_SYSTEM) != 0)
+                )
+            )
+            if (results.size >= limit) {
+                break
+            }
+        }
+        return McpResponse.ok(mapOf("count" to results.size, "apps" to results))
+    }
+}
+
+class SaveScriptTool(
+    private val appContext: Context
+) : McpTool {
+    override suspend fun handle(params: JsonObject?): McpResponse {
+        val request = try {
+            gson.fromJson(params, SaveScriptRequest::class.java)
+        } catch (e: Exception) {
+            return McpResponse.error("BadRequest", "Invalid request: ${e.message}")
+        }
+        if (request.script.isBlank()) {
+            return McpResponse.error("BadRequest", "script is required")
+        }
+        val scriptDir = File(getScriptDirPath(appContext))
+        if (!scriptDir.exists() && !scriptDir.mkdirs()) {
+            return McpResponse.error("Failed", "failed to create script dir")
+        }
+        var name = request.name?.trim().orEmpty()
+        if (name.isBlank()) {
+            name = "mcp-script-${System.currentTimeMillis()}.js"
+        }
+        name = name.replace(Regex("[\\\\/]+"), "_")
+        if (!name.endsWith(".js")) {
+            name += ".js"
+        }
+        val target = File(scriptDir, name)
+        if (target.exists() && request.overwrite != true) {
+            return McpResponse.error("AlreadyExists", "script already exists")
+        }
+        target.writeText(request.script)
+        return McpResponse.ok(
+            mapOf(
+                "path" to target.absolutePath,
+                "name" to target.name,
+                "size" to target.length()
+            )
+        )
+    }
+}
+
+class RunScriptFileTool(
+    private val appContext: Context,
+    private val tracker: JobTracker
+) : McpTool {
+    override suspend fun handle(params: JsonObject?): McpResponse {
+        val request = try {
+            gson.fromJson(params, RunScriptFileRequest::class.java)
+        } catch (e: Exception) {
+            return McpResponse.error("BadRequest", "Invalid request: ${e.message}")
+        }
+        if (request.path.isBlank()) {
+            return McpResponse.error("BadRequest", "path is required")
+        }
+        val file = resolveScriptFile(appContext, request.path)
+        if (!file.exists()) {
+            return McpResponse.error("NotFound", "script file not found")
+        }
+        val job = tracker.newJob(request.name ?: file.nameWithoutExtension)
+        val listener = object : BinderScriptListener {
+            override fun onStart(taskInfo: com.stardust.autojs.servicecomponents.TaskInfo) {
+                tracker.update(job.jobId, JobStatus.Status.RUNNING, "started")
+            }
+
+            override fun onSuccess(taskInfo: com.stardust.autojs.servicecomponents.TaskInfo) {
+                tracker.update(job.jobId, JobStatus.Status.SUCCESS, "completed")
+            }
+
+            override fun onException(taskInfo: com.stardust.autojs.servicecomponents.TaskInfo, e: Throwable) {
+                tracker.update(job.jobId, JobStatus.Status.FAILED, e.message)
+            }
+        }
+        EngineController.runScript(file, listener, null)
+        return McpResponse.ok(mapOf("jobId" to job.jobId, "path" to file.absolutePath))
+    }
+}
+
+class ListScriptsTool(
+    private val appContext: Context
+) : McpTool {
+    override suspend fun handle(params: JsonObject?): McpResponse {
+        val request = try {
+            if (params == null) ListScriptsRequest() else gson.fromJson(params, ListScriptsRequest::class.java)
+        } catch (e: Exception) {
+            return McpResponse.error("BadRequest", "Invalid request: ${e.message}")
+        }
+        val root = File(getScriptDirPath(appContext))
+        if (!root.exists()) {
+            return McpResponse.ok(mapOf("count" to 0, "scripts" to emptyList<Map<String, Any>>()))
+        }
+        val query = request.query?.trim()?.lowercase(Locale.getDefault())
+        val limit = request.limit?.takeIf { it > 0 } ?: Int.MAX_VALUE
+        val results = ArrayList<Map<String, Any>>(minOf(64, limit))
+
+        val matcher: (String) -> Boolean = { value ->
+            query.isNullOrEmpty() || value.lowercase(Locale.getDefault()).contains(query)
+        }
+
+        fun addFile(file: File) {
+            val relative = root.toPath().relativize(file.toPath()).toString().replace('\\', '/')
+            if (!matcher(relative) && !matcher(file.name)) {
+                return
+            }
+            results.add(
+                mapOf(
+                    "path" to relative,
+                    "name" to file.name,
+                    "size" to file.length(),
+                    "modified" to file.lastModified()
+                )
+            )
+        }
+
+        if (request.recursive == true) {
+            val stack = ArrayDeque<File>()
+            stack.add(root)
+            while (stack.isNotEmpty() && results.size < limit) {
+                val current = stack.removeFirst()
+                val children = current.listFiles().orEmpty()
+                for (child in children) {
+                    if (child.isDirectory) {
+                        stack.add(child)
+                    } else if (isScriptFile(child)) {
+                        addFile(child)
+                        if (results.size >= limit) {
+                            break
+                        }
+                    }
+                }
+            }
+        } else {
+            val children = root.listFiles().orEmpty()
+            for (child in children) {
+                if (child.isFile && isScriptFile(child)) {
+                    addFile(child)
+                    if (results.size >= limit) {
+                        break
+                    }
+                }
+            }
+        }
+
+        results.sortBy { it["path"] as String }
+        return McpResponse.ok(mapOf("count" to results.size, "scripts" to results))
+    }
+}
+
+class ListSamplesTool(
+    private val appContext: Context
+) : McpTool {
+    override suspend fun handle(params: JsonObject?): McpResponse {
+        val request = try {
+            if (params == null) ListSamplesRequest() else gson.fromJson(params, ListSamplesRequest::class.java)
+        } catch (e: Exception) {
+            return McpResponse.error("BadRequest", "Invalid request: ${e.message}")
+        }
+        val assets = appContext.assets
+        val root = "sample"
+        val query = request.query?.trim()?.lowercase(Locale.getDefault())
+        val limit = request.limit?.takeIf { it > 0 } ?: Int.MAX_VALUE
+        val results = ArrayList<Map<String, Any?>>(minOf(64, limit))
+
+        val matcher: (String) -> Boolean = { value ->
+            query.isNullOrEmpty() || value.lowercase(Locale.getDefault()).contains(query)
+        }
+
+        val stack = ArrayDeque<String>()
+        stack.add(root)
+        while (stack.isNotEmpty() && results.size < limit) {
+            val current = stack.removeFirst()
+            val children = assets.list(current).orEmpty()
+            for (child in children) {
+                val childPath = if (current.isBlank()) child else "$current/$child"
+                val nested = assets.list(childPath).orEmpty()
+                if (nested.isNotEmpty()) {
+                    stack.add(childPath)
+                    continue
+                }
+                if (!isSampleTextFile(childPath)) {
+                    continue
+                }
+                val relative = childPath.removePrefix("$root/").replace('\\', '/')
+                if (!matcher(relative) && !matcher(child)) {
+                    continue
+                }
+                results.add(
+                    mapOf(
+                        "path" to relative,
+                        "name" to child,
+                        "size" to getAssetSize(assets, childPath)
+                    )
+                )
+                if (results.size >= limit) {
+                    break
+                }
+            }
+        }
+        results.sortBy { it["path"] as String }
+        return McpResponse.ok(mapOf("count" to results.size, "samples" to results))
+    }
+}
+
+class ReadSampleTool(
+    private val appContext: Context
+) : McpTool {
+    override suspend fun handle(params: JsonObject?): McpResponse {
+        val request = try {
+            gson.fromJson(params, ReadSampleRequest::class.java)
+        } catch (e: Exception) {
+            return McpResponse.error("BadRequest", "Invalid request: ${e.message}")
+        }
+        val assetPath = resolveSamplePath(request.path)
+            ?: return McpResponse.error("BadRequest", "path is invalid")
+        if (!isSampleTextFile(assetPath)) {
+            return McpResponse.error("BadRequest", "not a text sample")
+        }
+        val assets = appContext.assets
+        val content = try {
+            assets.open(assetPath).bufferedReader().use { it.readText() }
+        } catch (e: Exception) {
+            return McpResponse.error("NotFound", "sample not found")
+        }
+        val name = assetPath.substringAfterLast('/')
+        return McpResponse.ok(
+            mapOf(
+                "path" to assetPath.removePrefix("sample/"),
+                "name" to name,
+                "size" to getAssetSize(assets, assetPath),
+                "content" to content
+            )
+        )
+    }
+}
+
+class ReadScriptTool(
+    private val appContext: Context
+) : McpTool {
+    override suspend fun handle(params: JsonObject?): McpResponse {
+        val request = try {
+            gson.fromJson(params, ReadScriptRequest::class.java)
+        } catch (e: Exception) {
+            return McpResponse.error("BadRequest", "Invalid request: ${e.message}")
+        }
+        val file = resolveScriptFileInDir(appContext, request.path)
+            ?: return McpResponse.error("BadRequest", "path is invalid")
+        if (!file.exists() || !file.isFile) {
+            return McpResponse.error("NotFound", "script file not found")
+        }
+        if (!isScriptFile(file)) {
+            return McpResponse.error("BadRequest", "not a script file")
+        }
+        val content = try {
+            file.readText()
+        } catch (e: Exception) {
+            return McpResponse.error("Failed", "read failed: ${e.message}")
+        }
+        return McpResponse.ok(
+            mapOf(
+                "path" to file.absolutePath,
+                "name" to file.name,
+                "size" to file.length(),
+                "script" to content
+            )
+        )
+    }
+}
+
+class UpdateScriptTool(
+    private val appContext: Context
+) : McpTool {
+    override suspend fun handle(params: JsonObject?): McpResponse {
+        val request = try {
+            gson.fromJson(params, UpdateScriptRequest::class.java)
+        } catch (e: Exception) {
+            return McpResponse.error("BadRequest", "Invalid request: ${e.message}")
+        }
+        if (request.script.isBlank()) {
+            return McpResponse.error("BadRequest", "script is required")
+        }
+        val file = resolveScriptFileInDir(appContext, request.path)
+            ?: return McpResponse.error("BadRequest", "path is invalid")
+        if (!file.exists() || !file.isFile) {
+            return McpResponse.error("NotFound", "script file not found")
+        }
+        if (!isScriptFile(file)) {
+            return McpResponse.error("BadRequest", "not a script file")
+        }
+        try {
+            file.writeText(request.script)
+        } catch (e: Exception) {
+            return McpResponse.error("Failed", "write failed: ${e.message}")
+        }
+        return McpResponse.ok(
+            mapOf(
+                "path" to file.absolutePath,
+                "name" to file.name,
+                "size" to file.length(),
+                "modified" to file.lastModified()
+            )
+        )
+    }
+}
+
+class DeleteScriptTool(
+    private val appContext: Context
+) : McpTool {
+    override suspend fun handle(params: JsonObject?): McpResponse {
+        val request = try {
+            gson.fromJson(params, DeleteScriptRequest::class.java)
+        } catch (e: Exception) {
+            return McpResponse.error("BadRequest", "Invalid request: ${e.message}")
+        }
+        val file = resolveScriptFileInDir(appContext, request.path)
+            ?: return McpResponse.error("BadRequest", "path is invalid")
+        if (!file.exists() || !file.isFile) {
+            return McpResponse.error("NotFound", "script file not found")
+        }
+        if (!isScriptFile(file)) {
+            return McpResponse.error("BadRequest", "not a script file")
+        }
+        if (!file.delete()) {
+            return McpResponse.error("Failed", "delete failed")
+        }
+        return McpResponse.ok(mapOf("path" to file.absolutePath, "deleted" to true))
+    }
+}
+
+class RenameScriptTool(
+    private val appContext: Context
+) : McpTool {
+    override suspend fun handle(params: JsonObject?): McpResponse {
+        val request = try {
+            gson.fromJson(params, RenameScriptRequest::class.java)
+        } catch (e: Exception) {
+            return McpResponse.error("BadRequest", "Invalid request: ${e.message}")
+        }
+        val file = resolveScriptFileInDir(appContext, request.path)
+            ?: return McpResponse.error("BadRequest", "path is invalid")
+        if (!file.exists() || !file.isFile) {
+            return McpResponse.error("NotFound", "script file not found")
+        }
+        if (!isScriptFile(file)) {
+            return McpResponse.error("BadRequest", "not a script file")
+        }
+        val newName = normalizeScriptName(file, request.newName)
+            ?: return McpResponse.error("BadRequest", "newName is invalid")
+        val target = File(file.parentFile, newName)
+        if (target.exists()) {
+            return McpResponse.error("AlreadyExists", "target already exists")
+        }
+        if (!file.renameTo(target)) {
+            return McpResponse.error("Failed", "rename failed")
+        }
+        return McpResponse.ok(
+            mapOf(
+                "path" to target.absolutePath,
+                "name" to target.name
+            )
+        )
+    }
+}
+
+class ListScriptDirsTool(
+    private val appContext: Context
+) : McpTool {
+    override suspend fun handle(params: JsonObject?): McpResponse {
+        val request = try {
+            if (params == null) ListScriptDirsRequest() else gson.fromJson(params, ListScriptDirsRequest::class.java)
+        } catch (e: Exception) {
+            return McpResponse.error("BadRequest", "Invalid request: ${e.message}")
+        }
+        val root = File(getScriptDirPath(appContext))
+        if (!root.exists()) {
+            return McpResponse.ok(mapOf("root" to root.absolutePath, "count" to 0, "dirs" to emptyList<Map<String, Any>>()))
+        }
+        val query = request.query?.trim()?.lowercase(Locale.getDefault())
+        val limit = request.limit?.takeIf { it > 0 } ?: Int.MAX_VALUE
+        val results = ArrayList<Map<String, Any>>(minOf(64, limit))
+
+        val matcher: (String) -> Boolean = { value ->
+            query.isNullOrEmpty() || value.lowercase(Locale.getDefault()).contains(query)
+        }
+
+        fun addDir(dir: File) {
+            val relative = root.toPath().relativize(dir.toPath()).toString().replace('\\', '/')
+            if (relative.isEmpty()) {
+                return
+            }
+            if (!matcher(relative) && !matcher(dir.name)) {
+                return
+            }
+            results.add(
+                mapOf(
+                    "path" to relative,
+                    "name" to dir.name,
+                    "modified" to dir.lastModified()
+                )
+            )
+        }
+
+        if (request.recursive == true) {
+            val stack = ArrayDeque<File>()
+            stack.add(root)
+            while (stack.isNotEmpty() && results.size < limit) {
+                val current = stack.removeFirst()
+                val children = current.listFiles().orEmpty()
+                for (child in children) {
+                    if (child.isDirectory) {
+                        if (child != root) {
+                            addDir(child)
+                            if (results.size >= limit) {
+                                break
+                            }
+                        }
+                        stack.add(child)
+                    }
+                }
+            }
+        } else {
+            val children = root.listFiles().orEmpty()
+            for (child in children) {
+                if (child.isDirectory) {
+                    addDir(child)
+                    if (results.size >= limit) {
+                        break
+                    }
+                }
+            }
+        }
+
+        results.sortBy { it["path"] as String }
+        return McpResponse.ok(mapOf("root" to root.absolutePath, "count" to results.size, "dirs" to results))
+    }
+}
+
+class NotImplementedTool(private val name: String) : McpTool {
+    override suspend fun handle(params: JsonObject?): McpResponse {
+        return McpResponse.error("NotImplemented", "$name not implemented yet")
+    }
+}
+
+private fun getScriptDirPath(context: Context): String {
+    val prefs = PreferenceManager.getDefaultSharedPreferences(context)
+    val configured = prefs.getString("key_script_dir_path", null)
+    val fallback = getStringResource(context, "default_value_script_dir_path") ?: "/scripts/"
+    val dir = configured?.takeIf { it.isNotBlank() } ?: fallback
+    return File(Environment.getExternalStorageDirectory(), dir).path
+}
+
+private fun getStringResource(context: Context, name: String): String? {
+    val resId = context.resources.getIdentifier(name, "string", context.packageName)
+    return if (resId != 0) context.getString(resId) else null
+}
+
+private fun resolveSamplePath(path: String): String? {
+    val normalized = path.trim().replace('\\', '/')
+    if (normalized.isBlank() || normalized.startsWith("/")) {
+        return null
+    }
+    if (normalized.split('/').any { it == ".." }) {
+        return null
+    }
+    return if (normalized.startsWith("sample/")) normalized else "sample/$normalized"
+}
+
+private fun resolveScriptFile(context: Context, path: String): File {
+    val input = path.trim()
+    val file = File(input)
+    return if (file.isAbsolute) {
+        file
+    } else {
+        File(getScriptDirPath(context), input)
+    }
+}
+
+private fun resolveScriptFileInDir(context: Context, path: String): File? {
+    val input = path.trim()
+    if (input.isBlank()) {
+        return null
+    }
+    val root = try {
+        File(getScriptDirPath(context)).canonicalFile
+    } catch (_: Exception) {
+        return null
+    }
+    val candidate = File(input)
+    val resolved = if (candidate.isAbsolute) candidate else File(root, input)
+    val canonical = try {
+        resolved.canonicalFile
+    } catch (_: Exception) {
+        return null
+    }
+    val rootPath = root.path.trimEnd(File.separatorChar) + File.separatorChar
+    return if (canonical.path.startsWith(rootPath)) canonical else null
+}
+
+private fun normalizeScriptName(original: File, newName: String): String? {
+    val trimmed = newName.trim()
+    if (trimmed.isBlank() || trimmed.contains('/') || trimmed.contains('\\')) {
+        return null
+    }
+    var name = trimmed
+    if (!isScriptName(name)) {
+        val ext = original.extension
+        name = if (ext.isNotBlank()) "$name.$ext" else "$name.js"
+    }
+    return if (isScriptName(name)) name else null
+}
+
+private fun isScriptName(name: String): Boolean {
+    val lower = name.lowercase(Locale.getDefault())
+    return lower.endsWith(".js") || lower.endsWith(".auto") || lower.endsWith(".mjs") ||
+        lower.endsWith(".cjs") || lower.endsWith("node.js")
+}
+
+private fun isScriptFile(file: File): Boolean {
+    return isScriptName(file.name)
+}
+
+private fun isSampleTextFile(path: String): Boolean {
+    val lower = path.lowercase(Locale.getDefault())
+    return lower.endsWith(".js") || lower.endsWith(".auto") || lower.endsWith(".mjs") ||
+        lower.endsWith(".cjs") || lower.endsWith(".json") || lower.endsWith(".md") ||
+        lower.endsWith(".txt") || lower.endsWith(".xml") || lower.endsWith(".yml") ||
+        lower.endsWith(".yaml") || lower.endsWith(".py")
+}
+
+private fun getAssetSize(assets: android.content.res.AssetManager, path: String): Long? {
+    return try {
+        assets.openFd(path).use { it.length }
+    } catch (_: Exception) {
+        try {
+            assets.open(path).use { it.available().toLong() }
+        } catch (_: Exception) {
+            null
+        }
+    }
+}

--- a/mcp/src/main/java/org/autojs/autoxjs/mcp/tools/JobTracker.kt
+++ b/mcp/src/main/java/org/autojs/autoxjs/mcp/tools/JobTracker.kt
@@ -1,0 +1,38 @@
+package org.autojs.autoxjs.mcp.tools
+
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
+
+data class JobStatus(
+    val jobId: Int,
+    val name: String,
+    val status: Status,
+    val message: String? = null
+) {
+    enum class Status {
+        SUBMITTED, RUNNING, SUCCESS, FAILED, CANCELED
+    }
+}
+
+class JobTracker {
+    private val idGen = AtomicInteger(1)
+    private val jobs = ConcurrentHashMap<Int, JobStatus>()
+
+    fun newJob(name: String): JobStatus {
+        val id = idGen.getAndIncrement()
+        val status = JobStatus(id, name, JobStatus.Status.SUBMITTED)
+        jobs[id] = status
+        return status
+    }
+
+    fun update(id: Int, status: JobStatus.Status, message: String? = null) {
+        val existing = jobs[id]
+        if (existing != null) {
+            jobs[id] = existing.copy(status = status, message = message)
+        }
+    }
+
+    fun get(id: Int): JobStatus? = jobs[id]
+
+    fun recent(limit: Int = 20): List<JobStatus> = jobs.values.sortedBy { it.jobId }.takeLast(limit)
+}

--- a/mcp/src/main/res/values/strings.xml
+++ b/mcp/src/main/res/values/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="mcp_notification_channel_name">MCP Server</string>
+    <string name="mcp_notification_channel_desc">In-app MCP server</string>
+    <string name="mcp_notification_title">MCP server running</string>
+    <string name="mcp_notification_text">LLM tools are available on the configured host</string>
+</resources>

--- a/mcp/src/test/java/org/autojs/autoxjs/mcp/McpJsonRpcHandlerTest.kt
+++ b/mcp/src/test/java/org/autojs/autoxjs/mcp/McpJsonRpcHandlerTest.kt
@@ -1,0 +1,145 @@
+package org.autojs.autoxjs.mcp
+
+import com.google.gson.JsonParser
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.runBlocking
+import org.autojs.autoxjs.mcp.tool.McpTool
+import org.autojs.autoxjs.mcp.tool.ToolDefinition
+import org.autojs.autoxjs.mcp.tool.ToolRegistry
+import org.autojs.autoxjs.mcp.tool.ToolSchemas
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class McpJsonRpcHandlerTest {
+    private fun handlerWithTool(): McpJsonRpcHandler {
+        val registry = ToolRegistry()
+        registry.register(
+            ToolDefinition(
+                name = "echo",
+                title = "Echo",
+                description = "Echo arguments",
+                inputSchema = ToolSchemas.objectSchema(
+                    mapOf("value" to ToolSchemas.stringSchema("Echo value."))
+                )
+            ),
+            McpTool { params -> McpResponse.ok(mapOf("echo" to params?.get("value")?.asString)) }
+        )
+        return McpJsonRpcHandler(
+            registry,
+            serverInfoProvider = { McpServerInfo(name = "TestServer", title = "Test", version = "1.0.0") }
+        )
+    }
+
+    @Test
+    fun initializeReturnsCapabilities() = runBlocking {
+        val handler = handlerWithTool()
+        val request = JsonParser.parseString(
+            """
+            {
+              "jsonrpc": "2.0",
+              "id": 1,
+              "method": "initialize",
+              "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": { "name": "TestClient" }
+              }
+            }
+            """.trimIndent()
+        ).asJsonObject
+        val response = handler.handleJson(request)
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = response.body
+        assertNotNull(body)
+        val result = body!!.getAsJsonObject("result")
+        assertEquals("2024-11-05", result.get("protocolVersion").asString)
+        assertTrue(result.getAsJsonObject("capabilities").has("tools"))
+    }
+
+    @Test
+    fun listToolsReturnsDefinitions() = runBlocking {
+        val handler = handlerWithTool()
+        val request = JsonParser.parseString(
+            """
+            {
+              "jsonrpc": "2.0",
+              "id": "list-1",
+              "method": "tools/list",
+              "params": {}
+            }
+            """.trimIndent()
+        ).asJsonObject
+        val response = handler.handleJson(request)
+        assertEquals(HttpStatusCode.OK, response.status)
+        val tools = response.body!!
+            .getAsJsonObject("result")
+            .getAsJsonArray("tools")
+        assertEquals(1, tools.size())
+        assertEquals("echo", tools[0].asJsonObject.get("name").asString)
+    }
+
+    @Test
+    fun callToolReturnsResult() = runBlocking {
+        val handler = handlerWithTool()
+        val request = JsonParser.parseString(
+            """
+            {
+              "jsonrpc": "2.0",
+              "id": 7,
+              "method": "tools/call",
+              "params": {
+                "name": "echo",
+                "arguments": { "value": "hello" }
+              }
+            }
+            """.trimIndent()
+        ).asJsonObject
+        val response = handler.handleJson(request)
+        assertEquals(HttpStatusCode.OK, response.status)
+        val result = response.body!!.getAsJsonObject("result")
+        assertFalse(result.get("isError").asBoolean)
+        val content = result.getAsJsonArray("content")
+        assertTrue(content[0].asJsonObject.get("text").asString.contains("hello"))
+    }
+
+    @Test
+    fun unknownToolReturnsErrorResult() = runBlocking {
+        val handler = handlerWithTool()
+        val request = JsonParser.parseString(
+            """
+            {
+              "jsonrpc": "2.0",
+              "id": 9,
+              "method": "tools/call",
+              "params": {
+                "name": "missing",
+                "arguments": {}
+              }
+            }
+            """.trimIndent()
+        ).asJsonObject
+        val response = handler.handleJson(request)
+        val result = response.body!!.getAsJsonObject("result")
+        assertTrue(result.get("isError").asBoolean)
+    }
+
+    @Test
+    fun initializedNotificationReturnsAccepted() = runBlocking {
+        val handler = handlerWithTool()
+        val request = JsonParser.parseString(
+            """
+            {
+              "jsonrpc": "2.0",
+              "method": "notifications/initialized"
+            }
+            """.trimIndent()
+        ).asJsonObject
+        val response = handler.handleJson(request)
+        assertEquals(HttpStatusCode.Accepted, response.status)
+        assertNull(response.body)
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,8 +1,6 @@
-plugins {
-    // 自动下载项目所需的JDK版本
-    id("org.gradle.toolchains.foojay-resolver-convention") version ("1.0.0")
-}
+// Note: foojay-resolver-convention disabled to avoid Gradle 8.7 compatibility issues.
 
 include(":app", ":automator", ":common", ":autojs", ":inrt", ":apkbuilder")
 include(":paddleocr")
 include(":codeeditor")
+include(":mcp")


### PR DESCRIPTION
添加大模型的mcp服务支持，能够让大模型自动调试、开发、验证 autojs脚本