### PR TITLE
fix libppocrv5ncnn.so not found error

### DIFF
--- a/autojs/src/main/java/com/stardust/autojs/project/Constant.kt
+++ b/autojs/src/main/java/com/stardust/autojs/project/Constant.kt
@@ -13,11 +13,7 @@ object Constant {
         val GOOGLE_ML_KIT_OCR = listOf("libmlkit_google_ocr_pipeline.so")
         val PADDLE_OCR = listOf(
             "libc++_shared.so",
-            "libpaddle_light_api_shared.so",
-            "libhiai.so",
-            "libhiai_ir.so",
-            "libhiai_ir_build.so",
-            "libNative.so"
+            "libppocrv5ncnn.so"
         )
         val TESSERACT_OCR = listOf(
             "libtesseract.so",


### PR DESCRIPTION
修复 打包paddle后 缺少 libppocrv5ncnn.so