### PR TITLE
fix: skip empty-name entries when unzipping APK

### DIFF
--- a/common/src/main/java/com/stardust/io/Zip.kt
+++ b/common/src/main/java/com/stardust/io/Zip.kt
@@ -17,6 +17,8 @@ object Zip {
                 var z: ZipEntry?
                 while (zis.nextEntry.also { z = it } != null) {
                     val entry = z ?: continue
+                    //部分APK(zipflinger/aapt2打包)会包含文件名为空的条目，跳过，避免把目录当文件打开导致EISDIR
+                    if (entry.name.isEmpty()) continue
                     val file = File(dir, entry.name)
                     if (entry.isDirectory) {
                         file.mkdirs()


### PR DESCRIPTION
修复打包时  解压template.zip遇到空名文件导致打包失败的问题